### PR TITLE
fix: preflight hardening for CI, release, and validation contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [develop, master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -24,7 +32,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: latest
+          version: "1.8.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
 
@@ -41,7 +49,7 @@ jobs:
         run: poetry run mypy src/
 
       - name: Run tests
-        run: poetry run pytest --cov=sbom_validator --cov-report=xml --cov-report=term
+        run: poetry run pytest --cov=sbom_validator --cov-fail-under=90 --cov-report=xml --cov-report=term
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,33 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build-linux:
+  verify-tag-provenance:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit belongs to master or develop
+        run: |
+          git fetch origin master develop
+          if git branch -r --contains "$GITHUB_SHA" | grep -Eq "origin/(master|develop)$"; then
+            echo "Tag commit is on an approved branch."
+          else
+            echo "Tag commit is not on master or develop."
+            exit 1
+          fi
+
+  build-linux:
+    needs: verify-tag-provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +48,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: latest
+          version: "1.8.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
 
@@ -37,13 +61,20 @@ jobs:
       - name: Smoke test
         run: ./dist/sbom-validator --version
 
+      - name: Generate checksums
+        run: sha256sum dist/sbom-validator > dist/sbom-validator.sha256
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/sbom-validator
+          files: |
+            dist/sbom-validator
+            dist/sbom-validator.sha256
 
   build-windows:
+    needs: verify-tag-provenance
     runs-on: windows-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash
@@ -56,7 +87,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install poetry==1.8.3
 
       - name: Install dependencies
         run: poetry install --with dev
@@ -67,7 +98,12 @@ jobs:
       - name: Smoke test
         run: ./dist/sbom-validator.exe --version
 
+      - name: Generate checksums
+        run: sha256sum dist/sbom-validator.exe > dist/sbom-validator.exe.sha256
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/sbom-validator.exe
+          files: |
+            dist/sbom-validator.exe
+            dist/sbom-validator.exe.sha256

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The file is checked against the seven elements mandated by the NTIA "Framing Sof
 | Author | FR-09 | The SBOM must identify at least one author |
 | Timestamp | FR-10 | The SBOM must include a creation timestamp |
 
-All issues from both stages are reported in a single pass — the tool never stops at the first error.
+The tool reports all issues within each stage in a single pass. If schema validation fails, NTIA checks are skipped by design.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sbom-validator"
-version = "0.1.0"
+version = "0.2.0"
 description = "CLI tool to validate SBOM files against schema and NTIA minimum elements"
 authors = []
 license = "Apache-2.0"

--- a/src/sbom_validator/__init__.py
+++ b/src/sbom_validator/__init__.py
@@ -1,3 +1,3 @@
 """SBOM Validator — validates SPDX 2.3 and CycloneDX 1.6 JSON files."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/sbom_validator/ntia_checker.py
+++ b/src/sbom_validator/ntia_checker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 
 from sbom_validator.models import IssueSeverity, NormalizedSBOM, ValidationIssue
 
@@ -126,13 +127,31 @@ def _check_author(sbom: NormalizedSBOM) -> list[ValidationIssue]:
 
 
 def _check_timestamp(sbom: NormalizedSBOM) -> list[ValidationIssue]:
-    """FR-10: The SBOM must contain a non-empty timestamp."""
+    """FR-10: The SBOM must contain a valid ISO 8601 timestamp."""
     if sbom.timestamp is None or sbom.timestamp.strip() == "":
         return [
             ValidationIssue(
                 severity=IssueSeverity.ERROR,
                 field_path="timestamp",
                 message=("SBOM is missing a creation timestamp (NTIA FR-10)"),
+                rule="FR-10",
+            )
+        ]
+
+    raw_timestamp = sbom.timestamp.strip()
+    # Accept "Z" suffix by normalizing to a UTC offset for fromisoformat().
+    normalized = raw_timestamp[:-1] + "+00:00" if raw_timestamp.endswith("Z") else raw_timestamp
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError:
+        return [
+            ValidationIssue(
+                severity=IssueSeverity.ERROR,
+                field_path="timestamp",
+                message=(
+                    f"SBOM timestamp '{raw_timestamp}' is not a valid ISO 8601 date-time "
+                    "(NTIA FR-10)"
+                ),
                 rule="FR-10",
             )
         ]

--- a/src/sbom_validator/report_writer.py
+++ b/src/sbom_validator/report_writer.py
@@ -10,7 +10,7 @@ import importlib.metadata
 import json
 import logging
 import string
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sbom_validator.models import IssueSeverity, ValidationResult
@@ -163,11 +163,11 @@ def _escape(text: str) -> str:
 
 
 def _tool_version() -> str:
-    """Return the installed package version, falling back to '0.2.0'."""
+    """Return the installed package version, falling back to 'unknown'."""
     try:
         return importlib.metadata.version("sbom-validator")
     except importlib.metadata.PackageNotFoundError:
-        return "0.2.0"
+        return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -195,8 +195,9 @@ def write_reports(
                  be written (e.g., permission denied).
     """
     # Compute shared timestamp and stems once.
-    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
-    generated_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_utc = datetime.now(UTC)
+    timestamp = now_utc.strftime("%Y%m%d-%H%M%S")
+    generated_at = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
     stem = Path(result.file_path).stem
     version = _tool_version()
 
@@ -220,32 +221,6 @@ def write_reports(
     error_count = sum(1 for i in result.issues if i.severity == IssueSeverity.ERROR)
     warning_count = sum(1 for i in result.issues if i.severity == IssueSeverity.WARNING)
     info_count = sum(1 for i in result.issues if i.severity == IssueSeverity.INFO)
-
-    # -----------------------------------------------------------------------
-    # Build JSON report
-    # -----------------------------------------------------------------------
-    json_data: dict[object, object] = {
-        "generated_at": generated_at,
-        "tool_version": version,
-        "file_path": result.file_path,
-        "format_detected": format_detected_expanded,
-        "status": str(result.status),
-        "summary": {
-            "error_count": error_count,
-            "warning_count": warning_count,
-            "info_count": info_count,
-        },
-        "issues": [
-            {
-                "severity": str(issue.severity),
-                "rule": issue.rule,
-                "field_path": issue.field_path,
-                "message": issue.message,
-            }
-            for issue in sorted_issues
-        ],
-    }
-    json_path.write_text(json.dumps(json_data, indent=2), encoding="utf-8")
 
     # -----------------------------------------------------------------------
     # Build HTML report
@@ -289,6 +264,32 @@ def write_reports(
         issues_section=issues_section,
     )
     html_path.write_text(html_content, encoding="utf-8")
+
+    # -----------------------------------------------------------------------
+    # Build JSON report
+    # -----------------------------------------------------------------------
+    json_data: dict[object, object] = {
+        "generated_at": generated_at,
+        "tool_version": version,
+        "file_path": result.file_path,
+        "format_detected": format_detected_expanded,
+        "status": str(result.status),
+        "summary": {
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "info_count": info_count,
+        },
+        "issues": [
+            {
+                "severity": str(issue.severity),
+                "rule": issue.rule,
+                "field_path": issue.field_path,
+                "message": issue.message,
+            }
+            for issue in sorted_issues
+        ],
+    }
+    json_path.write_text(json.dumps(json_data, indent=2), encoding="utf-8")
 
     logger.info("Reports written: HTML=%s  JSON=%s", html_path, json_path)
 

--- a/src/sbom_validator/validator.py
+++ b/src/sbom_validator/validator.py
@@ -22,6 +22,16 @@ from sbom_validator.schema_validator import validate_schema
 logger = logging.getLogger(__name__)
 
 
+def _error_issue(message: str, rule: str = "SYS-ERROR") -> ValidationIssue:
+    """Build a consistent ERROR issue payload for tool/input failures."""
+    return ValidationIssue(
+        severity=IssueSeverity.ERROR,
+        field_path="",
+        message=message,
+        rule=rule,
+    )
+
+
 def validate(file_path: str | Path) -> ValidationResult:
     """Validate an SBOM file through the full pipeline.
 
@@ -45,11 +55,11 @@ def validate(file_path: str | Path) -> ValidationResult:
         format_name = detect_format(file_path)
         logger.info("Format detected: %s", format_name)
     except (ParseError, UnsupportedFormatError) as e:
-        logger.warning("Unexpected error during validation of %s: %s", str_path, e)
+        logger.warning("Validation input error for %s: %s", str_path, e)
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(),
+            issues=(_error_issue(str(e), rule="FR-01"),),
             format_detected=None,
         )
     except Exception as e:
@@ -57,14 +67,7 @@ def validate(file_path: str | Path) -> ValidationResult:
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(
-                ValidationIssue(
-                    severity=IssueSeverity.ERROR,
-                    field_path="",
-                    message=str(e),
-                    rule="",
-                ),
-            ),
+            issues=(_error_issue(str(e)),),
             format_detected=None,
         )
 
@@ -77,14 +80,7 @@ def validate(file_path: str | Path) -> ValidationResult:
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(
-                ValidationIssue(
-                    severity=IssueSeverity.ERROR,
-                    field_path="",
-                    message=str(e),
-                    rule="",
-                ),
-            ),
+            issues=(_error_issue(str(e)),),
             format_detected=format_name,
         )
 
@@ -109,18 +105,11 @@ def validate(file_path: str | Path) -> ValidationResult:
         else:
             sbom = parse_cyclonedx(file_path)
     except ParseError as e:
-        logger.warning("Unexpected error during validation of %s: %s", str_path, e)
+        logger.warning("Validation parse error for %s: %s", str_path, e)
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(
-                ValidationIssue(
-                    severity=IssueSeverity.ERROR,
-                    field_path="",
-                    message=str(e),
-                    rule="",
-                ),
-            ),
+            issues=(_error_issue(str(e)),),
             format_detected=format_name,
         )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from sbom_validator import __version__
 from sbom_validator.cli import main
 
 # ---------------------------------------------------------------------------
@@ -59,7 +60,7 @@ class TestCliVersion:
 
     def test_version_output_contains_version_string(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["--version"])
-        assert "0.1.0" in result.output
+        assert __version__ in result.output
 
 
 # ===========================================================================

--- a/tests/unit/test_ntia_checker.py
+++ b/tests/unit/test_ntia_checker.py
@@ -369,6 +369,16 @@ class TestNtiaCheckerTimestamp:
         issues = check_ntia(sbom)
         assert not any(i.rule == "FR-10" for i in issues)
 
+    def test_invalid_timestamp_string_detected(self) -> None:
+        sbom = _make_valid_sbom(timestamp="not-a-date")
+        issues = check_ntia(sbom)
+        assert any(i.rule == "FR-10" for i in issues)
+
+    def test_invalid_timestamp_format_detected(self) -> None:
+        sbom = _make_valid_sbom(timestamp="2024/01/15 10:30:00")
+        issues = check_ntia(sbom)
+        assert any(i.rule == "FR-10" for i in issues)
+
 
 # ===========================================================================
 # TestNtiaCheckerCollectAll

--- a/tests/unit/test_report_writer.py
+++ b/tests/unit/test_report_writer.py
@@ -463,7 +463,7 @@ class TestToolVersionFallback:
 
     def test_tool_version_fallback_when_package_not_found(self, tmp_path: Path) -> None:
         """When importlib.metadata.version raises PackageNotFoundError,
-        _tool_version() must return the hardcoded fallback '0.2.0'."""
+        _tool_version() must return the fallback 'unknown'."""
         from sbom_validator.report_writer import _tool_version
 
         with patch(
@@ -472,7 +472,7 @@ class TestToolVersionFallback:
         ):
             version = _tool_version()
 
-        assert version == "0.2.0"
+        assert version == "unknown"
 
     def test_write_reports_uses_fallback_version_in_json(self, tmp_path: Path) -> None:
         """When the package is not installed, write_reports must still produce a
@@ -484,4 +484,4 @@ class TestToolVersionFallback:
             _, json_path = write_reports(_pass_result(), tmp_path)
 
         data = json.loads(json_path.read_text(encoding="utf-8"))
-        assert data["tool_version"] == "0.2.0"
+        assert data["tool_version"] == "unknown"

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -237,6 +237,7 @@ class TestValidatorErrorScenarios:
     def test_nonexistent_file_returns_error(self, tmp_path: Path) -> None:
         result = validate(tmp_path / "nonexistent.json")
         assert result.status == ValidationStatus.ERROR
+        assert len(result.issues) >= 1
 
     def test_nonexistent_file_does_not_raise(self, tmp_path: Path) -> None:
         # The orchestrator must convert all exceptions to ERROR results
@@ -254,6 +255,7 @@ class TestValidatorErrorScenarios:
         bad_file.write_text("not json", encoding="utf-8")
         result = validate(bad_file)
         assert result.status == ValidationStatus.ERROR
+        assert len(result.issues) >= 1
 
     def test_invalid_json_does_not_raise(self, tmp_path: Path) -> None:
         bad_file = tmp_path / "bad.json"
@@ -268,6 +270,7 @@ class TestValidatorErrorScenarios:
         unknown.write_text('{"neither": "spdx nor cyclonedx"}', encoding="utf-8")
         result = validate(unknown)
         assert result.status == ValidationStatus.ERROR
+        assert len(result.issues) >= 1
 
     def test_unknown_format_does_not_raise(self, tmp_path: Path) -> None:
         unknown = tmp_path / "unknown.json"


### PR DESCRIPTION
## Summary
- harden CI workflow for active develop flow by adding PR triggers for develop, explicit permissions, concurrency controls, timeout, pinned Poetry version, and coverage enforcement (--cov-fail-under=90)
- harden release workflow with tag provenance verification, pinned Poetry setup on both OS jobs, timeout/concurrency controls, and SHA256 artifact checksums
- improve validation contracts by returning structured ERROR issues in validator error paths, enforcing FR-10 ISO 8601 timestamp validation, and aligning report writer timestamp/version fallback behavior
- align version references to 