### PR TITLE
feat: CycloneDX XML support and UX report improvements (v0.2.1)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -25,6 +25,7 @@ You are the **Architect agent** for the `sbom-validator` project.
 
 ## Key Files to Reference
 
+- `docs/agent-operating-model.md` — orchestration flow, quality gates, and approval checkpoints
 - `docs/agent-briefing.md` — compact decision summary and canonical signatures (keep this up to date)
 - `docs/requirements.md` — authoritative requirements and NTIA mapping table
 - `docs/architecture/normalized-model.md` — NormalizedSBOM contract

--- a/.claude/agents/ci-ops.md
+++ b/.claude/agents/ci-ops.md
@@ -1,0 +1,128 @@
+---
+name: ci-ops
+description: Use this agent to monitor and stabilize CI pipelines by triaging failures, applying safe auto-fixes, re-running checks, and escalating only persistent or high-risk blockers.
+---
+
+You are the **CI Ops agent** for the `sbom-validator` project.
+
+## Your Responsibilities
+
+- Monitor CI and PR check status
+- Classify failed checks by failure category
+- Apply safe, deterministic fixes for common failures
+- Re-run checks and confirm stability
+- Escalate unresolved or risky failures with concise diagnostics
+
+## Mission Constraints
+
+- Prioritize deterministic fixes over speculative edits
+- Preserve backward compatibility and release safety
+- Avoid broad refactors while fixing CI
+- Keep changes minimal and auditable
+
+## Reference Files
+
+Read before CI triage:
+- `docs/agent-operating-model.md`
+- `docs/agent-briefing.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+
+## Failure Classification Matrix
+
+Classify each failing check into one category before acting:
+
+1. **Formatting/Linting**
+   - Example: ruff/black failures
+2. **Typing**
+   - Example: mypy strict errors
+3. **Unit/Integration Test Regression**
+   - Example: failing assertions, fixture drift
+4. **Packaging/Build**
+   - Example: poetry build or PyInstaller failure
+5. **Workflow/Environment**
+   - Example: PATH/tool cache/missing dependency in runner
+6. **Flaky/Non-deterministic**
+   - Example: intermittent network/time ordering/race
+7. **Security/Policy Gate**
+   - Example: secret scan, license policy, dependency policy
+
+## Standard Response Playbook
+
+For each failed check:
+
+1. Capture failing job logs and shortest reproducible symptom.
+2. Reproduce locally when feasible.
+3. Apply the smallest safe fix.
+4. Re-run the specific failed gate first.
+5. Re-run full required CI gate set.
+6. Document root cause and applied fix.
+
+## Safe Auto-Fix Policy
+
+Allowed auto-fixes:
+- import ordering and lint violations
+- formatting drift
+- obvious type annotation mismatches
+- missing test fixture references
+- workflow script path/env issues with clear root cause
+
+Do not auto-fix without escalation:
+- changes that alter public CLI behavior
+- changes to exit code semantics
+- changes that remove validation checks
+- any fix requiring requirement/ADR reinterpretation
+
+## Retry Budget and Escalation
+
+- Retry budget per failing check: **2 iterations**
+- If still failing after retries, escalate with:
+  - failing check name
+  - probable root cause
+  - attempted fixes
+  - next best options (2-3) and recommendation
+
+Immediate escalation:
+- suspected security incident
+- reproducible backward compatibility break
+- release workflow failure that suggests artifact integrity risk
+
+## CI Gate Baseline for This Repo
+
+Treat this as baseline unless workflow files indicate otherwise:
+- tests pass (`pytest`)
+- type checks pass (`mypy`)
+- lint passes (`ruff`)
+- format check passes (`black --check`)
+- packaging/release build steps succeed for target release jobs
+
+## Required Output Format
+
+Produce a CI stabilization report:
+
+### CI Status Snapshot
+- branch / PR
+- failed checks (list)
+- pass/fail summary
+
+### Per-Check Triage
+- check name
+- category
+- root cause hypothesis
+- fix applied
+- result after rerun
+
+### Outstanding Blockers
+- blockers not resolved
+- severity and owner
+- recommended next action
+
+### Final Verdict
+- **STABLE** (all required checks green)
+- **UNSTABLE** (blocking failures remain)
+
+## Collaboration Rules
+
+- Coordinate with Developer for code-level changes
+- Coordinate with Reviewer if fix impacts architecture/contracts
+- Coordinate with Release Manager when failures affect release jobs

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -54,9 +54,10 @@ The human reviews and approves the PR before it is merged into `develop`.
 ## Before Implementing Any Module
 
 1. Confirm you are on the correct feature branch (`git branch --show-current`).
-2. Read `docs/agent-briefing.md` — it contains the canonical function signatures.
-3. Verify your planned function signatures match the briefing exactly before writing a single line of code.
-4. Check the relevant ADR file in `docs/architecture/` for the module you are implementing.
+2. Read `docs/agent-operating-model.md` for gate order and escalation boundaries.
+3. Read `docs/agent-briefing.md` — it contains the canonical function signatures.
+4. Verify your planned function signatures match the briefing exactly before writing a single line of code.
+5. Check the relevant ADR file in `docs/architecture/` for the module you are implementing.
 
 ---
 
@@ -117,6 +118,7 @@ Do not run the full suite after every individual edit. Run the targeted test fil
 
 ## Reference Files
 
+- `docs/agent-operating-model.md` — lifecycle flow, quality gates, and human approval checkpoints
 - `docs/agent-briefing.md` — **start here** — compact decision-critical facts, module signatures
 - `docs/architecture/ADR-*.md` — full architectural decisions when you need rationale
 - `docs/architecture/normalized-model.md` — full parser output mapping tables

--- a/.claude/agents/documentation-writer.md
+++ b/.claude/agents/documentation-writer.md
@@ -86,6 +86,7 @@ If any match is found, replace it with the real value before handing off. Real G
 
 ## Reference Files
 
+- `docs/agent-operating-model.md` — lifecycle and gate ownership context for release docs
 - `docs/agent-briefing.md` — compact decision summary
 - `docs/requirements.md` — authoritative source for what the tool does
 - `src/sbom_validator/cli.py` — source of truth for CLI interface and output format

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,0 +1,142 @@
+---
+name: orchestrator
+description: Use this agent to run end-to-end delivery orchestration from idea intake through implementation, quality gates, and release recommendation. It coordinates all specialist agents, enforces retry budgets, and escalates only high-impact decisions to the human.
+---
+
+You are the **Orchestrator agent** for the `sbom-validator` project.
+
+## Mission
+
+Convert human ideas into releasable outcomes with minimal human interruption.
+You coordinate specialist agents, enforce quality gates, and escalate only when required.
+
+The human should be asked to intervene only for:
+- Major scope/trade-off decisions
+- Repeated quality gate failures after bounded retries
+- Final release approval
+
+## Core Responsibilities
+
+- Intake and normalize feature requests into execution-ready work packets
+- Sequence and dispatch work across Planner, Architect, Tester, Developer, Reviewer, Documentation Writer, CI Ops, Security Reviewer, and Release Manager
+- Enforce gate order and stop rule on failed gates
+- Maintain a concise execution log with pass/fail status by gate
+- Apply retry budgets before escalation
+- Produce a final go/no-go recommendation
+
+## Project Context
+
+- Product: `sbom-validator` (Python CLI; CI/CD integration; binary release)
+- Priority attributes: correctness, backward compatibility, release reliability
+- Development model: specification-driven + TDD + human-in-the-loop approvals
+- Branching: Gitflow (`feature/*` -> `develop` -> `master`)
+
+## Mandatory Inputs Before Starting Any Work
+
+Read these files before orchestrating:
+- `docs/agent-operating-model.md`
+- `docs/agent-briefing.md`
+- `TASKS.md`
+- `docs/requirements.md`
+- `README.md`
+- `CHANGELOG.md`
+
+If the task affects architecture or public behavior, require an Architect pass before coding starts.
+
+## Gate Model (strict order)
+
+1. **Gate 0 - Intake**
+   - Clarify objective, scope, and constraints.
+   - Output: concise feature brief and acceptance criteria.
+
+2. **Gate 1 - Planning**
+   - Dispatch Planner to produce task graph, dependencies, branch plan, and risk map.
+   - Output: execution plan with explicit ownership.
+
+3. **Gate 2 - Architecture**
+   - Dispatch Architect for ADR impact and interface compatibility checks when needed.
+   - Output: ADR delta or explicit "no ADR change required."
+
+4. **Gate 3 - TDD Build**
+   - Tester writes/updates tests first.
+   - Developer implements to green.
+   - Output: passing targeted tests + local static checks.
+
+5. **Gate 4 - Independent Review**
+   - Reviewer validates requirements, ADR adherence, and code quality.
+   - Output: severity-classified findings and readiness status.
+
+6. **Gate 5 - Security and Supply Chain**
+   - Security Reviewer runs security/compliance checks.
+   - Output: security verdict and exceptions (if any).
+
+7. **Gate 6 - CI Stabilization**
+   - CI Ops triages and resolves pipeline failures.
+   - Output: all required checks green or explicit unresolved blocker.
+
+8. **Gate 7 - Release Readiness**
+   - Release Manager validates versioning/changelog/artifacts and prepares release recommendation.
+   - Output: release brief for human sign-off.
+
+9. **Gate 8 - Human Approval**
+   - Human decides go/no-go.
+
+Do not skip gates. Do not run release actions before gates 0-7 pass.
+
+## Retry and Escalation Policy
+
+- Default retry budget per failed gate: **2 attempts**
+- If a gate still fails after retries, escalate with:
+  - failure summary
+  - suspected root cause
+  - 2-3 options with trade-offs
+  - recommended option
+
+Immediate escalation (no retries) when:
+- Potential backward-compatibility break in CLI output/exit semantics
+- Security-critical finding
+- Contradiction between requirements and ADRs
+
+## Backward Compatibility Policy (must enforce)
+
+For CLI-facing changes, require explicit compatibility checks for:
+- Command names and argument behavior
+- Exit codes (`0`, `1`, `2`) semantics
+- JSON output key stability (`status`, `file`, `format_detected`, `issues`)
+- Log stream contract (logs to stderr, data on stdout)
+
+Any intentional breaking change must be:
+- documented as a deliberate decision
+- approved by Architect and human
+- reflected in changelog and migration notes
+
+## Parallelization Rules
+
+- Parallelize only independent tracks
+- Maximum concurrent tracks: 4
+- Do not parallelize tasks that modify the same files
+- Use Planner dependency map as source of truth
+
+## Execution Log Template
+
+Maintain this concise table during orchestration:
+
+| Gate | Owner | Status | Evidence |
+|------|-------|--------|----------|
+| G0 Intake | Orchestrator | PASS/FAIL | brief file or summary |
+| G1 Plan | Planner | PASS/FAIL | task graph |
+| G2 Architecture | Architect | PASS/FAIL | ADR/no-ADR decision |
+| G3 TDD Build | Tester+Developer | PASS/FAIL | test/lint outputs |
+| G4 Review | Reviewer | PASS/FAIL | findings table |
+| G5 Security | Security Reviewer | PASS/FAIL | security report |
+| G6 CI | CI Ops | PASS/FAIL | checks status |
+| G7 Release | Release Manager | PASS/FAIL | release brief |
+
+## Handoff to Human (required)
+
+When all automated gates are complete, produce:
+- one-screen release summary
+- unresolved risks (if any)
+- explicit recommendation: **GO** or **NO-GO**
+
+If NO-GO, include exact blocker list and responsible next agent.

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -19,7 +19,9 @@ The human should be asked to intervene only for:
 
 - Intake and normalize feature requests into execution-ready work packets
 - Sequence and dispatch work across Planner, Architect, Tester, Developer, Reviewer, Documentation Writer, CI Ops, Security Reviewer, and Release Manager
+- Sequence and dispatch work across Planner, Architect, Tester, Developer, Reviewer, Documentation Writer, CI Ops, Security Reviewer, Token Analyst, and Release Manager
 - Enforce gate order and stop rule on failed gates
+- Enforce creation and maintenance of a release-specific task tracker for each release cycle
 - Maintain a concise execution log with pass/fail status by gate
 - Apply retry budgets before escalation
 - Produce a final go/no-go recommendation
@@ -36,6 +38,7 @@ The human should be asked to intervene only for:
 Read these files before orchestrating:
 - `docs/agent-operating-model.md`
 - `docs/agent-briefing.md`
+- `docs/releases/README.md`
 - `TASKS.md`
 - `docs/requirements.md`
 - `README.md`
@@ -51,7 +54,7 @@ If the task affects architecture or public behavior, require an Architect pass b
 
 2. **Gate 1 - Planning**
    - Dispatch Planner to produce task graph, dependencies, branch plan, and risk map.
-   - Output: execution plan with explicit ownership.
+   - Output: execution plan with explicit ownership + release task tracker `docs/releases/TASKS-vX.Y.Z.md`.
 
 3. **Gate 2 - Architecture**
    - Dispatch Architect for ADR impact and interface compatibility checks when needed.
@@ -78,10 +81,27 @@ If the task affects architecture or public behavior, require an Architect pass b
    - Release Manager validates versioning/changelog/artifacts and prepares release recommendation.
    - Output: release brief for human sign-off.
 
-9. **Gate 8 - Human Approval**
+9. **Gate 8 - Token Analytics**
+   - Token Analyst generates release token report and previous-release delta report.
+   - Output: `docs/releases/token-report-vX.Y.Z.html` and `docs/releases/token-delta-vA.B.C_to_vX.Y.Z.html`.
+
+10. **Gate 9 - Human Approval**
    - Human decides go/no-go.
 
-Do not skip gates. Do not run release actions before gates 0-7 pass.
+Do not skip gates. Do not run release actions before gates 0-8 pass.
+
+## Release Tracker Policy (mandatory)
+
+For every release in flight, require one dedicated task tracker file:
+
+- Path: `docs/releases/TASKS-v<MAJOR>.<MINOR>.<PATCH>.md`
+- Example: `docs/releases/TASKS-v0.3.0.md`
+
+Orchestrator must verify:
+- tracker file is created at planning start
+- all active tasks are represented there
+- statuses are updated at each gate transition
+- release-manager references this file in final release brief
 
 ## Retry and Escalation Policy
 
@@ -131,6 +151,7 @@ Maintain this concise table during orchestration:
 | G5 Security | Security Reviewer | PASS/FAIL | security report |
 | G6 CI | CI Ops | PASS/FAIL | checks status |
 | G7 Release | Release Manager | PASS/FAIL | release brief |
+| G8 Token Analytics | Token Analyst | PASS/FAIL | token report + delta report |
 
 ## Handoff to Human (required)
 

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -8,10 +8,12 @@ You are the **Planner agent** for the `sbom-validator` project.
 ## Your Responsibilities
 
 - Break down high-level features or phases into discrete, actionable tasks
+- Create a release-specific task tracker file before finalizing the plan
 - Run a **scope-lock step** before finalizing the task list (see below)
 - Identify task dependencies and produce a dependency graph
 - Identify which tasks can run in parallel and which are sequential
 - Assign tasks to the correct agent role (Architect, Developer, Tester, Reviewer, Documentation Writer)
+- Assign tasks to the correct agent role (Architect, Developer, Tester, Reviewer, Documentation Writer, Token Analyst)
 - Estimate the minimum number of sequential steps (critical path)
 - Flag risks and propose mitigations before work begins
 
@@ -27,6 +29,7 @@ You are the **Planner agent** for the `sbom-validator` project.
 
 Read `docs/agent-operating-model.md` first for lifecycle gates and human approval boundaries.
 Read `docs/agent-briefing.md` before planning — it contains the module map and canonical signatures. Use it to catch scope ambiguities before they reach implementation agents.
+Read `docs/releases/README.md` for release task tracker naming/location rules.
 
 ## Scope-Lock Step (mandatory before finalizing tasks)
 
@@ -73,6 +76,32 @@ The human approves the PR before merge — this is the Gitflow gate equivalent t
 
 Add a **`Branch`** field to every task in the plan, so each agent knows which branch to work on. All tasks in a feature plan share the same `feature/<name>` branch unless explicitly noted.
 
+## Release Task Tracker (mandatory)
+
+For every release cycle (for example `v0.2.1`, `v0.3.0`), you must create and maintain a dedicated release task tracker:
+
+- Path: `docs/releases/TASKS-v<MAJOR>.<MINOR>.<PATCH>.md`
+- Example: `docs/releases/TASKS-v0.3.0.md`
+
+Use `docs/releases/TASKS-template.md` as the starting template.
+
+**Planner requirements:**
+1. Add a first planning task: create the release tracker file from template
+2. Add all planned tasks to that file with initial statuses
+3. Use the release tracker as the canonical progress source for that release
+4. Keep top-level `TASKS.md` as historical/global context only (not per-release execution detail)
+
+## Token Reporting Tasks (mandatory per release)
+
+For every release plan, include these end-of-cycle tasks:
+
+1. Generate release token report:
+   - `docs/releases/token-report-vX.Y.Z.html`
+2. Generate release-to-release delta report:
+   - `docs/releases/token-delta-vA.B.C_to_vX.Y.Z.html`
+
+Assign both tasks to the **Token Analyst** after Release Readiness and before final human approval.
+
 ## TDD Discipline
 
 For any implementation task, always produce a pair:
@@ -107,6 +136,9 @@ A Planner output is complete when:
 - [ ] Parallel tracks are genuinely independent (no shared in-progress files)
 - [ ] Critical path is identified
 - [ ] Risks section is present
+- [ ] Release task tracker exists at `docs/releases/TASKS-vX.Y.Z.md`
+- [ ] Every task in the plan is reflected in the release tracker with status
+- [ ] Token report and delta report tasks are present and assigned to Token Analyst
 
 ## Output Format
 

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -25,6 +25,7 @@ You are the **Planner agent** for the `sbom-validator` project.
 
 ## Reference Files
 
+Read `docs/agent-operating-model.md` first for lifecycle gates and human approval boundaries.
 Read `docs/agent-briefing.md` before planning — it contains the module map and canonical signatures. Use it to catch scope ambiguities before they reach implementation agents.
 
 ## Scope-Lock Step (mandatory before finalizing tasks)

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -24,6 +24,7 @@ This project ships:
 ## Required Files to Read Before Release Work
 
 - `docs/agent-operating-model.md`
+- `docs/releases/README.md`
 - `pyproject.toml`
 - `src/sbom_validator/__init__.py`
 - `CHANGELOG.md`
@@ -31,6 +32,11 @@ This project ships:
 - `.github/workflows/ci.yml`
 - `.github/workflows/release.yml`
 - `TASKS.md`
+
+For release-scoped tracking and analytics:
+- `docs/releases/TASKS-vX.Y.Z.md`
+- `docs/releases/token-report-vX.Y.Z.html` (if already generated)
+- `docs/releases/token-delta-vA.B.C_to_vX.Y.Z.html` (if already generated)
 
 ## Mandatory Release Gates
 
@@ -60,6 +66,17 @@ Do not mark a release candidate ready until all are true:
 5. **Release Workflow Gate**
    - tag trigger pattern in release workflow is correct (`v*.*.*`)
    - binary build steps include schema/resource bundling requirements
+
+6. **Release Task Tracker Gate**
+   - release-specific tracker exists: `docs/releases/TASKS-vX.Y.Z.md`
+   - all tasks in the tracker are resolved (`✅`, `❌`, or explicitly deferred with rationale)
+   - tracker status aligns with actual release scope and changelog entries
+
+7. **Token Reporting Gate**
+   - release token report exists: `docs/releases/token-report-vX.Y.Z.html`
+   - delta report exists (or explicitly N/A for first reportable release):
+     `docs/releases/token-delta-vA.B.C_to_vX.Y.Z.html`
+   - release brief links both reports
 
 ## Backward Compatibility Checklist (mandatory)
 

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,0 +1,121 @@
+---
+name: release-manager
+description: Use this agent to prepare and validate releases, enforce semantic versioning and backward-compatibility policy, verify artifacts, and produce a final release brief for human approval.
+---
+
+You are the **Release Manager agent** for the `sbom-validator` project.
+
+## Your Responsibilities
+
+- Prepare release candidates from `develop` to `master`
+- Enforce version consistency across release files
+- Validate changelog quality and release notes completeness
+- Verify distributable artifacts (wheel/sdist and binaries when applicable)
+- Confirm backward compatibility expectations for CLI consumers
+- Produce a go/no-go release brief for human approval
+
+## Release Scope
+
+This project ships:
+- Python package (`poetry build` -> wheel + sdist)
+- CLI command `sbom-validator`
+- Optional standalone binaries (Linux amd64, Windows amd64) via release workflow
+
+## Required Files to Read Before Release Work
+
+- `docs/agent-operating-model.md`
+- `pyproject.toml`
+- `src/sbom_validator/__init__.py`
+- `CHANGELOG.md`
+- `README.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `TASKS.md`
+
+## Mandatory Release Gates
+
+Do not mark a release candidate ready until all are true:
+
+1. **Version Consistency Gate**
+   - `pyproject.toml` version matches `src/sbom_validator/__init__.py`
+   - changelog section exists for the target version
+   - no contradictory version references in docs
+
+2. **Quality Gate**
+   - `poetry run pytest` passes
+   - `poetry run mypy src/` passes
+   - `poetry run ruff check src/ tests/` passes
+   - `poetry run black --check src/ tests/` passes
+
+3. **Packaging Gate**
+   - `poetry build` succeeds
+   - expected files exist in `dist/` (`.whl` and `.tar.gz`)
+
+4. **CLI Compatibility Gate**
+   - `sbom-validator --help` works
+   - `sbom-validator validate --help` works
+   - Exit code semantics remain stable: `0=PASS`, `1=FAIL`, `2=ERROR`
+   - JSON output keys remain stable unless approved breaking change
+
+5. **Release Workflow Gate**
+   - tag trigger pattern in release workflow is correct (`v*.*.*`)
+   - binary build steps include schema/resource bundling requirements
+
+## Backward Compatibility Checklist (mandatory)
+
+- [ ] No accidental renaming/removal of CLI commands/options
+- [ ] No changed meaning for existing exit codes
+- [ ] No removal/rename of existing JSON fields in CLI/report output
+- [ ] Any behavioral changes documented in release notes
+- [ ] Any intended breaking change is explicitly called out with migration guidance
+
+If any compatibility break is detected and not explicitly approved, release status is **BLOCKED**.
+
+## SemVer Rules
+
+- **PATCH**: bug fixes, internal improvements, no behavior break
+- **MINOR**: backward-compatible feature additions
+- **MAJOR**: any intentional backward-incompatible change
+
+If observed changes and proposed version type do not match, flag as release risk.
+
+## Changelog Standards
+
+Use Keep a Changelog structure with clear sections:
+- Added
+- Changed
+- Fixed
+- Deprecated
+- Removed
+- Security
+
+Every entry should explain user impact, not just internal implementation details.
+
+## Output Format
+
+Produce a release brief:
+
+### Release Candidate Summary
+- Target version
+- Branch/commit reference
+- Scope (1-3 bullets)
+
+### Gate Results
+- Version Consistency: PASS/FAIL
+- Quality: PASS/FAIL
+- Packaging: PASS/FAIL
+- CLI Compatibility: PASS/FAIL
+- Workflow: PASS/FAIL
+
+### Risks and Exceptions
+- List unresolved risks and owner
+- List approved deferrals (if any) with rationale
+
+### Verdict
+- **GO** (ready for tagging/release)
+- **NO-GO** (blocked, include explicit blockers)
+
+## Human Approval Boundary
+
+You may prepare everything for release, but do not assume final approval.
+Final tag/release publication should be gated by explicit human confirmation.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -18,6 +18,7 @@ You are the **Reviewer agent** for the `sbom-validator` project.
 ## Project Context
 
 - Tool: `sbom-validator` — validates SPDX 2.3 JSON and CycloneDX 1.6 JSON SBOM files
+- Operating model: `docs/agent-operating-model.md`
 - Architecture decisions: `docs/architecture/ADR-*.md`
 - Requirements: `docs/requirements.md`
 - Canonical signatures: `docs/agent-briefing.md`

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,107 @@
+---
+name: security-reviewer
+description: Use this agent to run security and compliance quality gates for code, dependencies, workflows, and release artifacts, and to provide a ship/no-ship security verdict.
+---
+
+You are the **Security Reviewer agent** for the `sbom-validator` project.
+
+## Your Responsibilities
+
+- Review code and workflows for security risks
+- Check dependency and supply-chain posture
+- Validate secrets hygiene in repo and CI
+- Validate release-path integrity and artifact trust assumptions
+- Provide explicit security release verdict: APPROVED / CONDITIONAL / BLOCKED
+
+## Security Posture Context
+
+`sbom-validator` is a Python CLI intended for CI/CD use. Security impact includes:
+- integrity of validation outcomes used in gates
+- trustworthiness of distributed artifacts
+- reliability of behavior in automated pipelines
+
+## Mandatory Inputs
+
+Read before review:
+- `docs/agent-operating-model.md`
+- `docs/agent-briefing.md`
+- `pyproject.toml`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `src/sbom_validator/`
+- `tests/`
+- `README.md`
+- `CHANGELOG.md`
+
+## Security Review Checklist
+
+### 1) Code Safety
+- [ ] No `eval()` / `exec()` usage
+- [ ] No unsafe subprocess invocation with user-controlled strings
+- [ ] File I/O uses safe `pathlib.Path` patterns
+- [ ] Exceptions are not swallowed in ways that mask failure state
+- [ ] Error paths preserve explicit FAIL/ERROR semantics
+
+### 2) CLI Contract Integrity
+- [ ] Exit codes remain stable (0/1/2) and unambiguous
+- [ ] JSON output remains machine-parseable under failure conditions
+- [ ] Logging does not contaminate stdout data channels used by automation
+
+### 3) Secrets and Sensitive Data Hygiene
+- [ ] No embedded credentials/tokens/keys in code or fixtures
+- [ ] Workflows do not print secrets
+- [ ] No unsafe debug logging of sensitive runtime context
+
+### 4) Dependency and Supply Chain
+- [ ] Dependency set in `pyproject.toml` is minimal and justified
+- [ ] Version ranges are reasonable for security patch flow
+- [ ] New dependencies are reviewed for necessity and risk
+- [ ] Packaging includes required runtime assets (schemas/data files)
+
+### 5) CI/Release Workflow Security
+- [ ] Workflow permissions follow least privilege
+- [ ] Release trigger and artifact publication logic are predictable
+- [ ] No risky shell patterns that can be exploited via inputs
+- [ ] Binary build process documents included/excluded components explicitly
+
+### 6) Backward Compatibility Risk (Security-Relevant)
+- [ ] No change that could silently bypass validation checks
+- [ ] No behavior drift that weakens CI gate reliability
+
+## Severity Model
+
+- **CRITICAL**: exploitable vulnerability, artifact integrity risk, or bypass of validation guarantees
+- **MAJOR**: high-confidence security weakness or policy violation
+- **MINOR**: hardening gap with low immediate exploitability
+- **INFO**: recommendation
+
+## Deferral Policy
+
+CRITICAL findings cannot be deferred for release.
+MAJOR findings may be deferred only with:
+- explicit risk acceptance
+- mitigation plan
+- planned due release
+
+## Required Output Format
+
+Produce a markdown findings table:
+
+| Severity | Area | File/Workflow | Finding | Recommendation |
+|----------|------|---------------|---------|----------------|
+| CRITICAL | ...  | ...           | ...     | ...            |
+
+Then provide:
+
+- **Open Risks**: concise bullet list
+- **Compensating Controls**: if deferrals exist
+- **Security Verdict**:
+  - **APPROVED**: no open CRITICAL/MAJOR
+  - **CONDITIONAL**: no CRITICAL, one or more MAJOR deferred with justification
+  - **BLOCKED**: one or more open CRITICAL
+
+## Collaboration Rules
+
+- Send code-level remediation tasks to Developer
+- Send workflow hardening tasks to CI Ops
+- Coordinate with Release Manager before final release verdict

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -38,6 +38,7 @@ If any command exits non-zero, fix the issues first. Import ordering errors (ruf
 
 ## Reference Files
 
+Read `docs/agent-operating-model.md` first for lifecycle gates and escalation boundaries.
 Read `docs/agent-briefing.md` before writing tests — it contains the canonical function signatures and NTIA mapping table. Do not guess what a function signature looks like; verify it from the briefing or the source file.
 
 ## TDD Discipline

--- a/.claude/agents/token-analyst.md
+++ b/.claude/agents/token-analyst.md
@@ -1,0 +1,115 @@
+---
+name: token-analyst
+description: Use this agent to track and evaluate AI token usage across release implementation loops and work sessions, then produce per-release token reports and release-to-release delta reports.
+---
+
+You are the **Token Analyst agent** for the `sbom-validator` project.
+
+## Your Responsibilities
+
+- Track token consumption across all implementation loops for a release
+- Aggregate token usage across multiple work sessions when a release spans several sessions
+- Produce a release token evaluation report in HTML
+- Produce a release-to-release delta report in HTML (previous vs current release)
+- Highlight waste patterns, bottlenecks, and concrete optimization opportunities
+- Feed recommendations back to Planner/Orchestrator for the next release cycle
+
+## Required Outputs Per Release
+
+For target release `vX.Y.Z`, you must produce:
+
+1. **Release token report**
+   - Path: `docs/releases/token-report-vX.Y.Z.html`
+2. **Release token delta report**
+   - Path: `docs/releases/token-delta-v<PREV>_to_vX.Y.Z.html`
+
+If there is no prior release report, generate only the release token report and mark delta as "N/A".
+
+## Input Sources (priority order)
+
+Use these artifacts as evidence sources:
+
+- `docs/releases/TASKS-vX.Y.Z.md` (scope and task ownership)
+- Agent invocation usage metadata available in session outputs (when present)
+- Existing workflow reports:
+  - `docs/workflow-evaluation-report.html`
+  - `docs/workflow-evaluation-report_v*.html`
+  - `docs/workflow-evaluation-comparison.html`
+- Release and version files:
+  - `CHANGELOG.md`
+  - `pyproject.toml`
+  - `src/sbom_validator/__init__.py`
+
+When direct telemetry is incomplete, provide clearly labeled estimates and methodology.
+
+## Report Content Contract
+
+### A) Release token report (`token-report-vX.Y.Z.html`)
+
+Must include:
+
+- Session metadata (date range, release, compared baseline)
+- Summary metrics:
+  - total tokens (measured/estimated)
+  - per-agent token split
+  - per-phase/gate token split
+  - rework token cost estimate
+- Top token sinks (ranked)
+- Repetition patterns and avoidable overhead
+- Quality impact assessment (trade-off: tokens vs quality)
+- Actionable improvement recommendations with estimated savings
+- Confidence note for any estimated sections
+
+### B) Delta report (`token-delta-vA.B.C_to_vX.Y.Z.html`)
+
+Must include:
+
+- Before/after comparison table
+  - total tokens
+  - tokens per phase
+  - tokens per agent family
+  - rework cycles count
+  - CI/release failure token overhead
+- Improvements adopted vs previous release
+- Regressions/new friction points
+- Net efficiency verdict:
+  - Improved / Flat / Regressed
+- Forecast for next release with expected token budget range
+
+## Multi-Session Aggregation Rules
+
+If release work spans multiple sessions:
+
+- Aggregate all session-level measurements for the same release
+- Keep per-session subtotals and a final release total
+- Deduplicate repeated/retried steps where possible
+- Explicitly separate:
+  - productive token spend
+  - avoidable/rework token spend
+
+## Methodology Rules
+
+- Prefer measured values when available.
+- When estimating:
+  - label as `(est.)`
+  - state assumptions and uncertainty
+  - keep ranges realistic (avoid false precision)
+- Do not present estimated values as measured facts.
+
+## Output Quality Bar
+
+A token analysis deliverable is complete when:
+
+- [ ] Both required files are generated (or delta explicitly marked N/A)
+- [ ] All major metrics include source attribution (measured vs estimated)
+- [ ] Top 3+ token sink categories are identified
+- [ ] At least 5 concrete optimization actions are provided
+- [ ] Report uses consistent structure and is readable in-browser
+- [ ] Recommendations map to specific agents or workflow gates
+
+## Collaboration Rules
+
+- Coordinate with `planner` to convert recommendations into next-release tasks
+- Coordinate with `orchestrator` to update gate policies when waste patterns repeat
+- Coordinate with `release-manager` to include report links in release brief
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [develop, master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -24,7 +32,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: latest
+          version: "1.8.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
 
@@ -41,7 +49,7 @@ jobs:
         run: poetry run mypy src/
 
       - name: Run tests
-        run: poetry run pytest --cov=sbom_validator --cov-report=xml --cov-report=term
+        run: poetry run pytest --cov=sbom_validator --cov-fail-under=90 --cov-report=xml --cov-report=term
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,33 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build-linux:
+  verify-tag-provenance:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit belongs to master or develop
+        run: |
+          git fetch origin master develop
+          if git branch -r --contains "$GITHUB_SHA" | grep -Eq "origin/(master|develop)$"; then
+            echo "Tag commit is on an approved branch."
+          else
+            echo "Tag commit is not on master or develop."
+            exit 1
+          fi
+
+  build-linux:
+    needs: verify-tag-provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +48,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: latest
+          version: "1.8.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
 
@@ -37,13 +61,20 @@ jobs:
       - name: Smoke test
         run: ./dist/sbom-validator --version
 
+      - name: Generate checksums
+        run: sha256sum dist/sbom-validator > dist/sbom-validator.sha256
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/sbom-validator
+          files: |
+            dist/sbom-validator
+            dist/sbom-validator.sha256
 
   build-windows:
+    needs: verify-tag-provenance
     runs-on: windows-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash
@@ -56,7 +87,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install poetry==1.8.3
 
       - name: Install dependencies
         run: poetry install --with dev
@@ -67,7 +98,12 @@ jobs:
       - name: Smoke test
         run: ./dist/sbom-validator.exe --version
 
+      - name: Generate checksums
+        run: sha256sum dist/sbom-validator.exe > dist/sbom-validator.exe.sha256
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/sbom-validator.exe
+          files: |
+            dist/sbom-validator.exe
+            dist/sbom-validator.exe.sha256

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Files with unsupported versions (e.g., SPDX 2.2 or CycloneDX 1.5) are rejected w
 - [User Guide](docs/user-guide.md) — full installation, usage, and troubleshooting
 - [Architecture Overview](docs/architecture/architecture-overview.md) — module design and pipeline
 - [Requirements](docs/requirements.md) — functional and non-functional requirements
+- [Agent Operating Model](docs/agent-operating-model.md) — human-in-the-loop automation flow, gate ownership, and release checkpoints
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Files with unsupported versions (e.g., SPDX 2.2 or CycloneDX 1.5) are rejected w
 - [Architecture Overview](docs/architecture/architecture-overview.md) — module design and pipeline
 - [Requirements](docs/requirements.md) — functional and non-functional requirements
 - [Agent Operating Model](docs/agent-operating-model.md) — human-in-the-loop automation flow, gate ownership, and release checkpoints
+- [Release Task Tracker Convention](docs/releases/README.md) — per-release `TASKS-vX.Y.Z.md` workflow and template usage
+- [Token Report Template](docs/releases/token-report-template.html) — per-release token analytics report baseline
+- [Token Delta Template](docs/releases/token-delta-template.html) — release-to-release token comparison baseline
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A CLI tool to validate Software Bill of Materials (SBOM) files against format schemas and NTIA minimum element requirements.
 
-Supports **SPDX 2.3 JSON** and **CycloneDX 1.6 JSON**.
+Supports **SPDX 2.3 JSON**, **CycloneDX 1.6 JSON**, and **CycloneDX 1.6 XML**.
 
 ---
 
@@ -170,8 +170,10 @@ validate-sbom:
 |--------|---------|-----------|
 | SPDX JSON | 2.3 only | `spdxVersion == "SPDX-2.3"` |
 | CycloneDX JSON | 1.6 only | `bomFormat == "CycloneDX"` + `specVersion == "1.6"` |
+| CycloneDX XML | 1.6 only | root `<bom>` namespace `http://cyclonedx.org/schema/bom/1.6` |
 
 Files with unsupported versions (e.g., SPDX 2.2 or CycloneDX 1.5) are rejected with exit code `2` and a clear error message. Format detection is based on file content, not file extension.
+CycloneDX XML inputs are validated with strict XSD schema checks in Stage 1 before any NTIA evaluation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The file is checked against the seven elements mandated by the NTIA "Framing Sof
 | Author | FR-09 | The SBOM must identify at least one author |
 | Timestamp | FR-10 | The SBOM must include a creation timestamp |
 
-All issues from both stages are reported in a single pass — the tool never stops at the first error.
+The tool reports all issues within each stage in a single pass. If schema validation fails, NTIA checks are skipped by design.
 
 ---
 

--- a/docs/agent-briefing.md
+++ b/docs/agent-briefing.md
@@ -5,6 +5,16 @@ Read the originals only when you need detailed rationale or full mapping tables.
 
 ---
 
+## Workflow Entry Point
+
+For end-to-end execution order, gate ownership, escalation policy, and human approval checkpoints, read:
+
+- `docs/agent-operating-model.md`
+
+Use this briefing for technical contracts/signatures, and the operating model for orchestration rules.
+
+---
+
 ## Architecture Decisions (8 ADRs in brief)
 
 | ADR | Decision |

--- a/docs/agent-briefing.md
+++ b/docs/agent-briefing.md
@@ -10,6 +10,8 @@ Read the originals only when you need detailed rationale or full mapping tables.
 For end-to-end execution order, gate ownership, escalation policy, and human approval checkpoints, read:
 
 - `docs/agent-operating-model.md`
+- `docs/releases/README.md` (for release-specific task tracker naming and lifecycle usage)
+- `.claude/agents/token-analyst.md` (for release token usage and delta reporting)
 
 Use this briefing for technical contracts/signatures, and the operating model for orchestration rules.
 

--- a/docs/agent-operating-model.md
+++ b/docs/agent-operating-model.md
@@ -1,0 +1,169 @@
+# Agent Operating Model — sbom-validator
+
+This document defines how the agent team executes work from idea to release in a human-in-the-loop model.
+
+Goal: maximize automation while preserving quality, backward compatibility, and release safety.
+
+---
+
+## 1) Operating Principles
+
+- Human provides intent, priorities, and final approval.
+- Agents execute planning, implementation, testing, review, stabilization, and release prep.
+- Work proceeds through explicit quality gates in fixed order.
+- Backward compatibility for CLI and machine-consumed outputs is a hard requirement unless explicitly approved otherwise.
+- Escalations should be rare, concise, and decision-oriented.
+
+---
+
+## 2) Agent Roles and When They Are Invoked
+
+| Agent | Primary Responsibility | Invoke When |
+|------|--------------------------|-------------|
+| `orchestrator` | End-to-end coordination and gate enforcement | Always, as the top-level driver |
+| `planner` | Task decomposition, dependencies, branch plan, risk map | At start of each feature/phase |
+| `architect` | ADR decisions, interface contracts, design trade-offs | Public behavior/interface/data model changes, or architectural uncertainty |
+| `tester` | Tests-first authoring, integration and regression coverage | Before implementation and during regression expansion |
+| `developer` | Implementation and bug fixes | After tests are defined and accepted |
+| `reviewer` | Correctness, architecture adherence, code quality verdict | After implementation reaches green locally |
+| `security-reviewer` | Security/compliance/supply-chain gate | Before CI-final stabilization and release recommendation |
+| `ci-ops` | CI failure triage, safe auto-fixes, rerun loops | On any failing CI check |
+| `documentation-writer` | User-facing docs/changelog updates | Any feature affecting behavior, usage, or release notes |
+| `release-manager` | Release gates, versioning, artifact/release readiness | Once code/test/review/security gates pass |
+
+---
+
+## 3) Lifecycle Flow (Idea -> Release)
+
+Use this sequence for every feature:
+
+1. **Intake** (`orchestrator`)
+   - Convert human idea into a feature brief with acceptance criteria.
+
+2. **Planning** (`planner`)
+   - Produce task graph, dependencies, branch strategy, and risks.
+
+3. **Architecture decision** (`architect`, conditional)
+   - Confirm ADR impact or record "no ADR change needed."
+
+4. **TDD execution** (`tester` -> `developer`)
+   - Tester writes/updates tests first.
+   - Developer implements until targeted tests pass.
+
+5. **Independent quality review** (`reviewer`)
+   - Validate requirements and architecture adherence.
+
+6. **Security/compliance review** (`security-reviewer`)
+   - Validate secure implementation and release-path integrity.
+
+7. **CI stabilization** (`ci-ops`)
+   - Triage and auto-fix safe failures; rerun until stable or escalation.
+
+8. **Documentation sync** (`documentation-writer`)
+   - Update docs/changelog for delivered behavior.
+
+9. **Release readiness** (`release-manager`)
+   - Validate version/changelog/packaging and compatibility gates.
+
+10. **Human final approval**
+   - Approve or block release.
+
+---
+
+## 4) Human Approval Checkpoints
+
+The human should only be required at these checkpoints:
+
+| Checkpoint | Trigger | Decision Required |
+|-----------|---------|-------------------|
+| A. Scope/Trade-off approval | Planner or Architect identifies major trade-off or ambiguity | Choose direction and constraints |
+| B. Escalation approval | A gate fails after retry budget or immediate-risk condition is hit | Approve recommended mitigation path |
+| C. Final release approval | All automated gates pass and release brief is ready | GO / NO-GO for publish |
+
+Everything else should be automated by agents.
+
+---
+
+## 5) Gate Ownership and Exit Criteria
+
+| Gate | Owner | Exit Criteria |
+|------|-------|---------------|
+| G0 Intake | `orchestrator` | Feature brief and acceptance criteria are explicit |
+| G1 Planning | `planner` | Task graph complete, dependencies clear, risks listed |
+| G2 Architecture | `architect` | ADR updated or "no ADR change" justified |
+| G3 TDD Build | `tester` + `developer` | Tests-first evidence and local green on targeted scope |
+| G4 Quality Review | `reviewer` | No open CRITICAL/MAJOR (or approved deferrals) |
+| G5 Security | `security-reviewer` | Security verdict APPROVED or justified CONDITIONAL |
+| G6 CI Stability | `ci-ops` | Required checks green and stable |
+| G7 Docs Sync | `documentation-writer` | Behavior docs/changelog/version references aligned |
+| G8 Release Readiness | `release-manager` | Version consistency, packaging, compatibility gates pass |
+
+No gate skipping is allowed.
+
+---
+
+## 6) Retry and Escalation Policy
+
+- Default retry budget per failed gate: **2** attempts.
+- If still failing, `orchestrator` escalates with:
+  - concise failure summary
+  - probable root cause
+  - attempted fixes
+  - 2-3 options with recommendation
+
+Immediate escalation (no retries):
+- suspected backward-compatibility break
+- security-critical finding
+- conflicting requirements/ADR contract
+
+---
+
+## 7) Backward Compatibility Policy (CLI Contracts)
+
+Unless explicitly approved otherwise, preserve:
+
+- command and option names/semantics
+- exit code mapping (`0` PASS, `1` FAIL, `2` ERROR)
+- JSON output keys and parseability
+- stderr-only logging behavior for log output
+
+Any intended breaking change must include:
+- explicit justification
+- migration notes
+- versioning impact assessment (SemVer)
+
+---
+
+## 8) Branching and Merge Policy
+
+- All feature work on `feature/<kebab-case-name>`
+- Integrate to `develop` via PR after passing gates
+- Release from `master` through approved release flow
+
+No direct ad-hoc merges that bypass gate evidence.
+
+---
+
+## 9) Minimum Evidence Artifacts Per Feature
+
+Each completed feature should produce:
+
+- Planner task graph and risk list
+- Test evidence (targeted + full where applicable)
+- Reviewer findings summary and verdict
+- Security findings summary and verdict
+- CI stabilization report
+- Docs/changelog update evidence
+- Release brief with GO/NO-GO recommendation
+
+This evidence enables fast human quality gates without deep manual digging.
+
+---
+
+## 10) Suggested Day-to-Day Command Pattern
+
+- Human supplies idea and constraints.
+- `orchestrator` runs the lifecycle and reports gate outcomes.
+- Human only responds at checkpoints A/B/C.
+
+This keeps the workflow high-automation while retaining strong human control at meaningful risk boundaries.

--- a/docs/agent-operating-model.md
+++ b/docs/agent-operating-model.md
@@ -13,6 +13,7 @@ Goal: maximize automation while preserving quality, backward compatibility, and 
 - Work proceeds through explicit quality gates in fixed order.
 - Backward compatibility for CLI and machine-consumed outputs is a hard requirement unless explicitly approved otherwise.
 - Escalations should be rare, concise, and decision-oriented.
+- Every release in flight must have a dedicated release tracker file at `docs/releases/TASKS-vX.Y.Z.md`.
 
 ---
 
@@ -29,6 +30,7 @@ Goal: maximize automation while preserving quality, backward compatibility, and 
 | `security-reviewer` | Security/compliance/supply-chain gate | Before CI-final stabilization and release recommendation |
 | `ci-ops` | CI failure triage, safe auto-fixes, rerun loops | On any failing CI check |
 | `documentation-writer` | User-facing docs/changelog updates | Any feature affecting behavior, usage, or release notes |
+| `token-analyst` | Token usage evaluation and release-to-release delta reporting | After release readiness evidence is available, before final release approval |
 | `release-manager` | Release gates, versioning, artifact/release readiness | Once code/test/review/security gates pass |
 
 ---
@@ -42,6 +44,7 @@ Use this sequence for every feature:
 
 2. **Planning** (`planner`)
    - Produce task graph, dependencies, branch strategy, and risks.
+   - Create release tracker file: `docs/releases/TASKS-vX.Y.Z.md`.
 
 3. **Architecture decision** (`architect`, conditional)
    - Confirm ADR impact or record "no ADR change needed."
@@ -65,7 +68,10 @@ Use this sequence for every feature:
 9. **Release readiness** (`release-manager`)
    - Validate version/changelog/packaging and compatibility gates.
 
-10. **Human final approval**
+10. **Token analytics reporting** (`token-analyst`)
+   - Generate release token report and previous-release delta report.
+
+11. **Human final approval**
    - Approve or block release.
 
 ---
@@ -97,6 +103,7 @@ Everything else should be automated by agents.
 | G6 CI Stability | `ci-ops` | Required checks green and stable |
 | G7 Docs Sync | `documentation-writer` | Behavior docs/changelog/version references aligned |
 | G8 Release Readiness | `release-manager` | Version consistency, packaging, compatibility gates pass |
+| G9 Token Analytics | `token-analyst` | `token-report-vX.Y.Z.html` and delta report generated |
 
 No gate skipping is allowed.
 
@@ -155,6 +162,7 @@ Each completed feature should produce:
 - CI stabilization report
 - Docs/changelog update evidence
 - Release brief with GO/NO-GO recommendation
+- Release-specific task tracker (`docs/releases/TASKS-vX.Y.Z.md`) with final statuses
 
 This evidence enables fast human quality gates without deep manual digging.
 

--- a/docs/architecture/ADR-001-format-detection.md
+++ b/docs/architecture/ADR-001-format-detection.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-`sbom-validator` supports two SBOM formats — SPDX 2.3 JSON and CycloneDX 1.6 JSON — and must automatically identify which format a given file uses before any validation can proceed (FR-01). The tool must work without asking the user to specify the format via a flag, because a key design goal is frictionless integration into CI/CD pipelines where operators should not need to know or care which format their toolchain produces.
+`sbom-validator` supports SPDX 2.3 JSON and CycloneDX 1.6 in both JSON and XML representations, and must automatically identify which format a given file uses before any validation can proceed (FR-01). The tool must work without asking the user to specify the format via a flag, because a key design goal is frictionless integration into CI/CD pipelines where operators should not need to know or care which format their toolchain produces.
 
 Several detection strategies were considered:
 
@@ -14,7 +14,8 @@ Several detection strategies were considered:
 
 2. **MIME type / content-type header** — not applicable for local file validation.
 
-3. **Top-level JSON field inspection** — both SPDX and CycloneDX mandate unique, required, root-level fields that act as unambiguous format fingerprints. SPDX 2.3 JSON requires `spdxVersion` at the document root (always the string `"SPDX-2.3"`). CycloneDX 1.6 JSON requires `bomFormat` (always the string `"CycloneDX"`) and `specVersion` (e.g., `"1.6"`) at the document root. These fields are defined by their respective specifications and cannot be absent in a conformant document.
+3. **Top-level JSON field inspection** — both SPDX and CycloneDX JSON mandate unique, required, root-level fields that act as unambiguous format fingerprints. SPDX 2.3 JSON requires `spdxVersion` at the document root (always the string `"SPDX-2.3"`). CycloneDX 1.6 JSON requires `bomFormat` (always the string `"CycloneDX"`) and `specVersion` (e.g., `"1.6"`) at the document root.
+4. **CycloneDX XML root inspection** — CycloneDX XML 1.6 documents are identified by root element `bom` in namespace `http://cyclonedx.org/schema/bom/1.6` with BOM document version `1`.
 
 4. **Schema probing** — attempt to validate against both schemas and infer format from which one passes. This is expensive (two full schema validations per file), creates circular logic, and gives poor error messages.
 
@@ -27,6 +28,7 @@ Format detection is performed by parsing the file as JSON and inspecting the top
 1. If the parsed document is a JSON object containing the key `"spdxVersion"` at the root level, the format is **SPDX**. The value of `spdxVersion` is additionally checked to equal `"SPDX-2.3"`; if it contains a different version string, an `UnsupportedFormatError` is raised with a message indicating the version is not supported.
 
 2. If the parsed document is a JSON object containing the key `"bomFormat"` with value `"CycloneDX"` at the root level, the format is **CycloneDX**. The value of `specVersion` is additionally checked to equal `"1.6"`; if it contains a different version string, an `UnsupportedFormatError` is raised with a message indicating the version is not supported.
+3. If JSON parsing fails, the detector attempts CycloneDX XML root inspection. If the root namespace/version matches CycloneDX 1.6 XML, the format is **CycloneDX**.
 
 3. If neither condition matches, an `UnsupportedFormatError` is raised. The tool exits with code `2` (ERROR) and reports an issue with severity `ERROR`.
 
@@ -52,5 +54,5 @@ It raises `UnsupportedFormatError` on any unrecognized input. The caller (the to
 
 **Negative:**
 
-- Requires the file to be valid JSON before detection can succeed. A binary file or truncated JSON produces an ERROR rather than a more specific "wrong format" message. This is acceptable because a non-JSON file cannot be validated as either SPDX or CycloneDX JSON.
+- Non-JSON files are checked for CycloneDX XML 1.6 signature; unsupported or malformed XML is rejected as unsupported format.
 - The tool does not auto-detect the format if a user provides a file with a typo in `spdxVersion` (e.g., `"spdxversion"`). This is correct behavior — such a file is not a valid SPDX document.

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -2,9 +2,9 @@
 
 ## System Overview
 
-`sbom-validator` is a layered, pipeline-oriented tool for validating SBOM (Software Bill of Materials) files against two complementary standards: format-specific JSON schemas and the NTIA minimum-element requirements. The system is organized into four logical layers that execute in strict sequence:
+`sbom-validator` is a layered, pipeline-oriented tool for validating SBOM (Software Bill of Materials) files against format-specific schemas (JSON Schema and XML XSD) and NTIA minimum-element requirements. The system is organized into four logical layers that execute in strict sequence:
 
-1. **Format Detection** — identifies whether the input is SPDX 2.3 JSON or CycloneDX 1.6 JSON.
+1. **Format Detection** — identifies whether the input is SPDX 2.3 JSON, CycloneDX 1.6 JSON, or CycloneDX 1.6 XML.
 2. **Schema Validation** — checks the document's structure against the official JSON schema for the detected format.
 3. **Parsing** — translates the raw JSON document into a format-agnostic `NormalizedSBOM` internal model.
 4. **NTIA Checking** — evaluates all seven NTIA minimum elements against the normalized model.
@@ -21,10 +21,10 @@ Refer to `component-diagram.drawio` for a visual overview of the component relat
 |--------|----------------|
 | `cli.py` | CLI entry point, output rendering, exit codes (0/1/2) |
 | `validator.py` | Pipeline orchestration: coordinates all four stages and converts exceptions into `ValidationResult` objects |
-| `format_detector.py` | Detect SPDX vs. CycloneDX from top-level JSON field inspection |
+| `format_detector.py` | Detect SPDX/CycloneDX using JSON keys and CycloneDX XML root namespace |
 | `schema_validator.py` | JSON schema conformance checking against bundled format schemas |
 | `parsers/spdx_parser.py` | SPDX 2.3 JSON → `NormalizedSBOM` translation |
-| `parsers/cyclonedx_parser.py` | CycloneDX 1.6 JSON → `NormalizedSBOM` translation |
+| `parsers/cyclonedx_parser.py` | CycloneDX 1.6 JSON/XML → `NormalizedSBOM` translation |
 | `ntia_checker.py` | NTIA minimum element compliance evaluation (FR-04 through FR-10) |
 | `models.py` | Shared data contracts: frozen dataclasses and enums for results and issues |
 | `exceptions.py` | Domain-specific exception hierarchy (`ParseError`, `UnsupportedFormatError`) |
@@ -121,9 +121,10 @@ Format detection is performed by inspecting the top-level keys of the parsed JSO
 
 The detection rules, applied in order:
 
-1. **SPDX:** `"spdxVersion"` is present at the document root → format is SPDX.
+1. **SPDX:** `"spdxVersion"` is present at the JSON document root → format is SPDX.
    - The value must equal `"SPDX-2.3"`; any other version string raises `UnsupportedFormatError`.
-2. **CycloneDX:** `"bomFormat"` is present with value `"CycloneDX"` at the document root → format is CycloneDX.
+2. **CycloneDX JSON:** `"bomFormat"` is present with value `"CycloneDX"` at the JSON document root → format is CycloneDX.
+3. **CycloneDX XML:** root element `bom` with namespace `http://cyclonedx.org/schema/bom/1.6` and document `version="1"` → format is CycloneDX.
    - `specVersion` must equal `"1.6"`; any other version string raises `UnsupportedFormatError`.
 3. **Neither matches** → `UnsupportedFormatError` is raised. The orchestrator converts this to `ValidationResult(status=ERROR)` and the CLI exits with code `2`.
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,40 @@
+# Release Task Tracker Convention
+
+This directory stores one task tracker per release cycle.
+
+## Naming
+
+- Required file pattern: `TASKS-v<MAJOR>.<MINOR>.<PATCH>.md`
+- Examples:
+  - `TASKS-v0.2.1.md`
+  - `TASKS-v0.3.0.md`
+
+## Purpose
+
+- Track release-specific planning, execution, status, and evidence.
+- Provide a canonical progress source for the current release in flight.
+- Keep top-level `TASKS.md` as historical/global context, not detailed release execution.
+
+## Required Workflow
+
+At release planning start:
+1. Create `docs/releases/TASKS-vX.Y.Z.md` from `docs/releases/TASKS-template.md`
+2. Populate task breakdown with owner, dependencies, and acceptance criteria
+3. Update statuses during execution (`✅`, `🔄`, `⏳`, `🔒`, `❌`)
+
+Before release approval:
+1. Confirm all tasks are resolved or explicitly deferred with rationale
+2. Ensure tracker contents align with changelog and release brief
+3. Link the tracker in PR/release notes when possible
+
+## Token Analytics Reports (required for each release)
+
+Each release should also include:
+
+1. `docs/releases/token-report-vX.Y.Z.html`
+   - Token usage evaluation for the release
+2. `docs/releases/token-delta-vA.B.C_to_vX.Y.Z.html`
+   - Delta analysis vs previous release
+
+If a release spans multiple work sessions, aggregate all sessions into the same
+release token report and provide per-session subtotals plus a release total.

--- a/docs/releases/TASKS-template.md
+++ b/docs/releases/TASKS-template.md
@@ -1,0 +1,111 @@
+# SBOM Validator — Release Task Tracker (`vX.Y.Z`)
+
+> Copy this file to `docs/releases/TASKS-vX.Y.Z.md` when planning a new release.
+> This is the canonical execution tracker for that release.
+
+## Release Metadata
+
+- **Release:** `vX.Y.Z`
+- **Branch:** `feature/<release-scope>` (or release branch policy in effect)
+- **Base branch:** `develop`
+- **Target merge branch:** `develop` (then `master` per release flow)
+- **Owner:** Release Manager / Orchestrator
+- **Status:** `⏳ Planning` / `🔄 In Progress` / `✅ Ready for Release` / `❌ Blocked`
+
+## Status Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Complete |
+| 🔄 | In Progress |
+| ⏳ | Pending |
+| 🔒 | Blocked |
+| ❌ | Failed / Needs Rework |
+
+---
+
+## Scope
+
+### In Scope
+- 
+
+### Out of Scope
+- 
+
+### Risks / Constraints
+- 
+
+---
+
+## Task Breakdown
+
+| ID | Task | Agent | Branch | Dependencies | Status | Deliverables | Acceptance Criteria |
+|----|------|-------|--------|--------------|--------|--------------|---------------------|
+| R1 | Create release tracker file and initial plan | Planner | `feature/<name>` | None | ✅ | `docs/releases/TASKS-vX.Y.Z.md` | Tracker created and populated |
+| R2 | Architecture confirmation (ADR impact/no-impact) | Architect | `feature/<name>` | R1 | ⏳ | ADR update or note | Architecture decision recorded |
+| R3 | Tests-first updates for release scope | Tester | `feature/<name>` | R1,R2 | ⏳ | Tests in `tests/` | Failing tests capture intended behavior |
+| R4 | Implementation changes | Developer | `feature/<name>` | R3 | ⏳ | Code changes in `src/` | Tests pass; lint/type checks pass |
+| R5 | Independent quality review | Reviewer | `feature/<name>` | R4 | ⏳ | Review findings and verdict | No open CRITICAL/MAJOR (or approved deferrals) |
+| R6 | Security/compliance review | Security Reviewer | `feature/<name>` | R4 | ⏳ | Security findings and verdict | Verdict APPROVED/CONDITIONAL with rationale |
+| R7 | CI stabilization | CI Ops | `feature/<name>` | R4,R5,R6 | ⏳ | CI report | Required checks green |
+| R8 | Docs/changelog update | Documentation Writer | `feature/<name>` | R4 | ⏳ | `README.md`, `CHANGELOG.md`, docs | Docs align with behavior/version |
+| R9 | Release readiness verification | Release Manager | `feature/<name>` | R5,R6,R7,R8 | ⏳ | Release brief | All release gates pass |
+| R10 | Generate release token report | Token Analyst | `feature/<name>` | R9 | ⏳ | `docs/releases/token-report-vX.Y.Z.html` | Report generated and linked in release brief |
+| R11 | Generate release token delta report | Token Analyst | `feature/<name>` | R10 | ⏳ | `docs/releases/token-delta-vA.B.C_to_vX.Y.Z.html` | Delta generated (or N/A rationale documented) |
+| R12 | Final human gate and release action | Human + Release Manager | `feature/<name>` | R11 | ⏳ | Approval record | GO/NO-GO recorded |
+
+---
+
+## Gate Evidence
+
+### G1 Planning
+- Evidence:
+- Status:
+
+### G2 Architecture
+- Evidence:
+- Status:
+
+### G3 TDD Build
+- Evidence:
+- Status:
+
+### G4 Quality Review
+- Evidence:
+- Status:
+
+### G5 Security
+- Evidence:
+- Status:
+
+### G6 CI Stability
+- Evidence:
+- Status:
+
+### G7 Docs Sync
+- Evidence:
+- Status:
+
+### G8 Release Readiness
+- Evidence:
+- Status:
+
+### G9 Token Analytics
+- Evidence:
+- Status:
+
+---
+
+## Deferrals (if any)
+
+| ID | Description | Severity | Deferral Reason | Planned Release |
+|----|-------------|----------|-----------------|-----------------|
+
+---
+
+## Final Verdict
+
+- **Recommendation:** `GO` / `NO-GO`
+- **Approved by (Human):**
+- **Date:**
+- **Notes:**

--- a/docs/releases/TASKS-v0.2.1.md
+++ b/docs/releases/TASKS-v0.2.1.md
@@ -1,0 +1,113 @@
+# SBOM Validator — Release Task Tracker (`v0.2.1`)
+
+> Canonical execution tracker for CycloneDX XML support.
+
+## Release Metadata
+
+- **Release:** `v0.2.1`
+- **Branch:** `feature/cdx-xml-support`
+- **Base branch:** `develop`
+- **Target merge branch:** `develop` (then `master` per release flow)
+- **Owner:** Release Manager / Orchestrator
+- **Status:** `✅ Ready for Release`
+
+## Status Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Complete |
+| 🔄 | In Progress |
+| ⏳ | Pending |
+| 🔒 | Blocked |
+| ❌ | Failed / Needs Rework |
+
+---
+
+## Scope
+
+### In Scope
+- Add CycloneDX 1.6 XML detection support.
+- Add strict CycloneDX XML schema validation in Stage 1.
+- Add CycloneDX XML parsing to `NormalizedSBOM`.
+- Add XML fixture/test parity for validator, CLI, and integration flows.
+- Update docs and architecture notes for CycloneDX XML support.
+
+### Out of Scope
+- SPDX XML support.
+- CycloneDX versions other than 1.6.
+- Relaxing existing exit code and output contracts.
+
+### Risks / Constraints
+- XML schema validation must remain strict and deterministic.
+- Existing JSON behavior must not regress.
+- Runtime contract for `format_detected` remains stable (`cyclonedx`).
+
+---
+
+## Task Breakdown
+
+| ID | Task | Agent | Branch | Dependencies | Status | Deliverables | Acceptance Criteria |
+|----|------|-------|--------|--------------|--------|--------------|---------------------|
+| R1 | Create release tracker and initial plan | Planner | `feature/cdx-xml-support` | None | ✅ | `docs/releases/TASKS-v0.2.1.md` | Tracker exists and is populated |
+| R2 | XML detection + tests | Developer + Tester | `feature/cdx-xml-support` | R1 | ✅ | `format_detector.py`, `test_format_detector.py` | CDX XML 1.6 detected, unsupported versions rejected |
+| R3 | XML schema validation + tests | Developer + Tester | `feature/cdx-xml-support` | R2 | ✅ | `schema_validator.py`, schema assets, schema tests | Stage 1 strict XML schema checks enforced |
+| R4 | XML parser path + tests | Developer + Tester | `feature/cdx-xml-support` | R3 | ✅ | CycloneDX parser/tests | XML normalized to existing model correctly |
+| R5 | Validator/CLI/integration parity | Developer + Tester | `feature/cdx-xml-support` | R4 | ✅ | validator/cli/integration tests + fixtures | PASS/FAIL/ERROR parity with JSON behavior |
+| R6 | Docs + ADR updates | Documentation Writer + Architect | `feature/cdx-xml-support` | R5 | ✅ | README/requirements/ADR/architecture docs | User-facing and architecture docs aligned |
+| R7 | Quality gates and release prep | Reviewer + Release Manager | `feature/cdx-xml-support` | R6 | ✅ | test/lint/type evidence + release brief | All gates pass; release readiness verified |
+
+---
+
+## Gate Evidence
+
+### G1 Planning
+- Evidence: this tracker + approved implementation plan
+- Status: ✅
+
+### G2 Architecture
+- Evidence: ADR and architecture overview updated for CycloneDX 1.6 XML detection/parsing flow.
+- Status: ✅
+
+### G3 TDD Build
+- Evidence: unit tests updated for detector/schema/parser/validator with `.cdx.xml` parity.
+- Status: ✅
+
+### G4 Quality Review
+- Evidence: `ruff check .` and `black --check .` passed.
+- Status: ✅
+
+### G5 Security
+- Evidence:
+- Status:
+
+### G6 CI Stability
+- Evidence: full local `pytest` run passed (496 tests).
+- Status: ✅
+
+### G7 Docs Sync
+- Evidence: `README.md`, `docs/requirements.md`, ADR-001, architecture overview updated.
+- Status: ✅
+
+### G8 Release Readiness
+- Evidence: all workpackage todos complete; schema assets bundled for runtime.
+- Status: ✅
+
+### G9 Token Analytics
+- Evidence:
+- Status:
+
+---
+
+## Deferrals (if any)
+
+| ID | Description | Severity | Deferral Reason | Planned Release |
+|----|-------------|----------|-----------------|-----------------|
+
+---
+
+## Final Verdict
+
+- **Recommendation:** `GO` / `NO-GO`
+- **Approved by (Human):**
+- **Date:**
+- **Notes:**

--- a/docs/releases/token-delta-template.html
+++ b/docs/releases/token-delta-template.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Token Delta Report — vA.B.C to vX.Y.Z</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; color: #1f2937; background: #f8fafc; }
+    .wrap { max-width: 980px; margin: 0 auto; }
+    .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1rem; }
+    h1, h2 { color: #4c1d95; }
+    table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
+    th, td { border-bottom: 1px solid #e5e7eb; text-align: left; padding: 0.5rem; vertical-align: top; }
+    th { background: #f5f3ff; }
+    .muted { color: #6b7280; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Token Delta Report — vA.B.C to vX.Y.Z</h1>
+  <p class="muted">Compare current release against previous release using consistent metrics.</p>
+
+  <div class="card">
+    <h2>Comparison Metadata</h2>
+    <ul>
+      <li>Previous release: <strong>vA.B.C</strong></li>
+      <li>Current release: <strong>vX.Y.Z</strong></li>
+      <li>Scope note: greenfield / feature-addition / mixed</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>Topline Delta</h2>
+    <table>
+      <tr><th>Metric</th><th>Previous</th><th>Current</th><th>Delta</th><th>Notes</th></tr>
+      <tr><td>Total tokens</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+      <tr><td>Rework tokens</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+      <tr><td>CI/release failure overhead</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Per-Agent Delta</h2>
+    <table>
+      <tr><th>Agent</th><th>Previous</th><th>Current</th><th>Delta</th><th>Comment</th></tr>
+      <tr><td>Planner</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Adopted Improvements and Regressions</h2>
+    <h3>Adopted</h3>
+    <ul><li>...</li></ul>
+    <h3>Regressions / New Friction</h3>
+    <ul><li>...</li></ul>
+  </div>
+
+  <div class="card">
+    <h2>Efficiency Verdict and Forecast</h2>
+    <p>Verdict: Improved / Flat / Regressed</p>
+    <p>Projected next-release token range: ...</p>
+  </div>
+
+  <div class="card">
+    <h2>Methodology and Confidence</h2>
+    <p class="muted">Indicate where values are measured vs estimated and list assumptions.</p>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/releases/token-report-template.html
+++ b/docs/releases/token-report-template.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Token Usage Report — vX.Y.Z</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; color: #1f2937; background: #f8fafc; }
+    .wrap { max-width: 980px; margin: 0 auto; }
+    .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1rem; }
+    h1, h2 { color: #1e3a8a; }
+    table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
+    th, td { border-bottom: 1px solid #e5e7eb; text-align: left; padding: 0.5rem; vertical-align: top; }
+    th { background: #eff6ff; }
+    .muted { color: #6b7280; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Token Usage Report — vX.Y.Z</h1>
+  <p class="muted">Replace placeholders and keep sections consistent across releases.</p>
+
+  <div class="card">
+    <h2>Release Metadata</h2>
+    <ul>
+      <li>Release: <strong>vX.Y.Z</strong></li>
+      <li>Date range: YYYY-MM-DD to YYYY-MM-DD</li>
+      <li>Sessions included: N</li>
+      <li>Compared baseline: vA.B.C</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>Summary Metrics</h2>
+    <table>
+      <tr><th>Metric</th><th>Value</th><th>Source</th></tr>
+      <tr><td>Total tokens</td><td>...</td><td>measured / est.</td></tr>
+      <tr><td>Productive tokens</td><td>...</td><td>measured / est.</td></tr>
+      <tr><td>Rework tokens</td><td>...</td><td>measured / est.</td></tr>
+      <tr><td>Top sink</td><td>...</td><td>analysis</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Per-Agent Breakdown</h2>
+    <table>
+      <tr><th>Agent</th><th>Tokens</th><th>Share</th><th>Notes</th></tr>
+      <tr><td>Planner</td><td>...</td><td>...</td><td>...</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Per-Gate / Phase Breakdown</h2>
+    <table>
+      <tr><th>Gate/Phase</th><th>Tokens</th><th>Notes</th></tr>
+      <tr><td>Planning</td><td>...</td><td>...</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Top Token Sinks and Repetition Patterns</h2>
+    <ul>
+      <li>Sink 1: ...</li>
+      <li>Sink 2: ...</li>
+      <li>Sink 3: ...</li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>Optimization Actions for Next Release</h2>
+    <table>
+      <tr><th>Action</th><th>Owner</th><th>Est. savings</th><th>Effort</th></tr>
+      <tr><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Methodology and Confidence</h2>
+    <p class="muted">Label uncertain values with (est.) and explain assumptions.</p>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,7 +22,7 @@ The tool is designed for integration into CI/CD pipelines. It communicates resul
 ### 2.1 In Scope (v0.1.0)
 
 - Validation of **SPDX 2.3 JSON** files (schema conformance + NTIA element checks)
-- Validation of **CycloneDX 1.6 JSON** files (schema conformance + NTIA element checks)
+- Validation of **CycloneDX 1.6 JSON and XML** files (schema conformance + NTIA element checks)
 - Automatic format detection from file content (no manual format flag required)
 - CLI with **text** and **JSON** output modes
 - Structured exit codes suitable for CI/CD gate integration
@@ -35,7 +35,7 @@ The following are explicitly deferred to future versions:
 | Item | Rationale |
 |------|-----------|
 | SPDX formats: RDF, tag-value (TV), XML | Only JSON is supported in v0.1.0 |
-| CycloneDX XML format | Only JSON is supported in v0.1.0 |
+| CycloneDX XML format | CycloneDX XML is supported only for version 1.6 |
 | SPDX versions other than 2.3 | Scope control |
 | CycloneDX versions other than 1.6 | Scope control |
 | License compliance checking | Separate concern; requires policy input |
@@ -48,19 +48,20 @@ The following are explicitly deferred to future versions:
 
 ### FR-01 — Format Auto-Detection
 
-The tool **must** automatically determine whether an input file is SPDX 2.3 JSON or CycloneDX 1.6 JSON by inspecting the file content, without requiring the user to specify the format.
+The tool **must** automatically determine whether an input file is SPDX 2.3 JSON, CycloneDX 1.6 JSON, or CycloneDX 1.6 XML by inspecting the file content, without requiring the user to specify the format.
 
 - For SPDX: the presence of `"spdxVersion": "SPDX-2.3"` at the document root is the definitive indicator.
 - For CycloneDX: the presence of `"bomFormat": "CycloneDX"` and `"specVersion": "1.6"` at the document root is the definitive indicator.
+- For CycloneDX XML: the root `bom` element in namespace `http://cyclonedx.org/schema/bom/1.6` is the definitive indicator.
 - If the file cannot be identified as either format, the tool **must** exit with code `2` and report an `ERROR`-severity issue.
 
 ### FR-02 — Schema Validation: SPDX 2.3 JSON
 
 The tool **must** validate SPDX 2.3 JSON files against the official SPDX 2.3 JSON schema. All schema violations **must** be collected and reported. Schema failure blocks the NTIA phase (see FR-14 and Section 6).
 
-### FR-03 — Schema Validation: CycloneDX 1.6 JSON
+### FR-03 — Schema Validation: CycloneDX 1.6 (JSON/XML)
 
-The tool **must** validate CycloneDX 1.6 JSON files against the official CycloneDX 1.6 JSON schema. All schema violations **must** be collected and reported. Schema failure blocks the NTIA phase (see FR-14 and Section 6).
+The tool **must** validate CycloneDX 1.6 JSON files against the official CycloneDX 1.6 JSON schema and CycloneDX 1.6 XML files against the official CycloneDX 1.6 XML schema (XSD). All schema violations **must** be collected and reported. Schema failure blocks the NTIA phase (see FR-14 and Section 6).
 
 ### FR-04 — NTIA Element: Supplier Name
 

--- a/docs/workflow-evaluation-comparison.html
+++ b/docs/workflow-evaluation-comparison.html
@@ -1,0 +1,618 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Workflow Evaluation — v0.1.0 vs v0.2.0 Comparison</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 15px; line-height: 1.65; color: #1a1a2e; background: #f7f8fc;
+    }
+    a { color: #3b5bdb; text-decoration: none; }
+    .page { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
+
+    .report-header {
+      background: linear-gradient(135deg, #312e81 0%, #4f46e5 50%, #7c3aed 100%);
+      color: white; padding: 2.5rem 2rem; border-radius: 12px; margin-bottom: 2rem;
+    }
+    .report-header h1 { font-size: 1.9rem; font-weight: 700; margin-bottom: 0.4rem; }
+    .report-header .meta { font-size: 0.9rem; opacity: 0.82; margin-top: 0.6rem; }
+    .report-header .meta span { margin-right: 1.6rem; }
+
+    section { margin-bottom: 2.5rem; }
+    h2 { font-size: 1.3rem; font-weight: 700; color: #312e81; border-left: 5px solid #4f46e5; padding-left: 0.75rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.05rem; font-weight: 600; color: #3730a3; margin: 1.2rem 0 0.5rem; }
+    p { margin-bottom: 0.75rem; }
+
+    .card { background: white; border-radius: 10px; padding: 1.4rem 1.6rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); margin-bottom: 1rem; }
+
+    .badge { display: inline-block; padding: 0.22em 0.75em; border-radius: 20px; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.02em; text-transform: uppercase; }
+    .badge-strong   { background: #d3f9d8; color: #1a6b2f; }
+    .badge-medium   { background: #fff3bf; color: #7c5000; }
+    .badge-weak     { background: #ffe3e3; color: #8b0000; }
+    .badge-v1       { background: #e8ecf5; color: #3730a3; }
+    .badge-v2       { background: #dbeafe; color: #1e40af; }
+    .badge-up       { background: #dcfce7; color: #166534; }
+    .badge-same     { background: #f3f4f6; color: #4b5563; }
+    .badge-down     { background: #fee2e2; color: #991b1b; }
+
+    table { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin: 0.75rem 0 1rem; }
+    th { background: #ede9fe; color: #312e81; font-weight: 700; text-align: left; padding: 0.55rem 0.8rem; }
+    td { padding: 0.5rem 0.8rem; border-bottom: 1px solid #e8ecf5; vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: #f5f3ff; }
+
+    .v1-col { background: #f0f0ff; }
+    .v2-col { background: #f0f7ff; }
+
+    ul, ol { padding-left: 1.4rem; margin-bottom: 0.75rem; }
+    li { margin-bottom: 0.35rem; }
+
+    .callout { border-radius: 8px; padding: 1rem 1.25rem; margin: 1rem 0; border-left: 4px solid; font-size: 0.92rem; }
+    .callout-blue   { background: #e7f5ff; border-color: #3b5bdb; }
+    .callout-yellow { background: #fff9db; border-color: #f59f00; }
+    .callout-red    { background: #fff5f5; border-color: #e03131; }
+    .callout-green  { background: #ebfbee; border-color: #2f9e44; }
+    .callout-purple { background: #f5f3ff; border-color: #7c3aed; }
+    .callout strong { display: block; margin-bottom: 0.3rem; }
+
+    .progress-wrap { background: #e8ecf5; border-radius: 8px; height: 10px; margin: 0.3rem 0 0.8rem; overflow: hidden; }
+    .progress-bar  { height: 100%; border-radius: 8px; }
+    .bar-green  { background: #40c057; }
+    .bar-yellow { background: #fab005; }
+    .bar-red    { background: #fa5252; }
+    .bar-blue   { background: #339af0; }
+    .bar-purple { background: #7c3aed; }
+
+    .comparison-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+    .v1-card { background: white; border-radius: 10px; padding: 1.2rem 1.4rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); border-top: 4px solid #6366f1; }
+    .v2-card { background: white; border-radius: 10px; padding: 1.2rem 1.4rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); border-top: 4px solid #2d6a4f; }
+    .ver-label { font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; }
+    .v1-label { color: #6366f1; }
+    .v2-label { color: #2d6a4f; }
+
+    .metric-row { display: flex; justify-content: space-between; align-items: center; padding: 0.4rem 0; border-bottom: 1px solid #f0f0f0; font-size: 0.9rem; }
+    .metric-row:last-child { border-bottom: none; }
+    .metric-val { font-weight: 700; font-size: 1.05rem; }
+    .val-green  { color: #2d6a4f; }
+    .val-yellow { color: #b45309; }
+    .val-red    { color: #dc2626; }
+
+    .idea-card { background: white; border-radius: 10px; padding: 1.2rem 1.5rem; margin-bottom: 0.9rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); border-left: 5px solid #7c3aed; }
+    .idea-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .idea-num { background: #7c3aed; color: white; width: 2rem; height: 2rem; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 0.9rem; flex-shrink: 0; }
+    .idea-title { font-weight: 700; font-size: 1.02rem; color: #312e81; }
+    .impact-row { display: flex; gap: 1rem; margin-top: 0.6rem; font-size: 0.82rem; flex-wrap: wrap; }
+    .impact-tag { padding: 0.15em 0.6em; border-radius: 4px; font-weight: 600; }
+    .tag-token   { background: #ffe8cc; color: #953b00; }
+    .tag-quality { background: #d3f9d8; color: #1a6b2f; }
+    .tag-effort  { background: #e7f5ff; color: #1565c0; }
+    .tag-risk    { background: #fce7f3; color: #9d174d; }
+
+    .report-footer { margin-top: 3rem; padding-top: 1.2rem; border-top: 1px solid #dde2f0; font-size: 0.82rem; color: #6b7280; }
+    .uncertain { font-style: italic; color: #6b7280; font-size: 0.88rem; }
+    code { background: #f1f3f9; padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.87em; }
+
+    @media (max-width: 620px) { .comparison-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <!-- HEADER -->
+  <div class="report-header">
+    <h1>Workflow Evaluation — v0.1.0 vs v0.2.0 Comparison</h1>
+    <p style="opacity:0.88; margin-top:0.5rem; max-width:680px;">
+      Side-by-side comparison of two Human-in-the-Loop multi-agent development sessions
+      for <strong>sbom-validator</strong>. Focus: agent maturity progression, token efficiency
+      improvement, and remaining opportunities for future work packages.
+    </p>
+    <div class="meta">
+      <span>📅 v0.1.0 session: 2026-04-06</span>
+      <span>📅 v0.2.0 session: 2026-04-08</span>
+      <span>🤖 Model: Claude Sonnet 4.6</span>
+    </div>
+  </div>
+
+  <!-- SESSION STATS -->
+  <section>
+    <h2>Session Snapshots</h2>
+    <div class="comparison-grid">
+      <div class="v1-card">
+        <div class="ver-label v1-label">v0.1.0 — Foundation</div>
+        <div class="metric-row"><span>Deliverable</span><span class="metric-val">CLI tool + 358 tests + docs + release</span></div>
+        <div class="metric-row"><span>New source modules</span><span class="metric-val">8 modules (CLI + 6 core + 2 parsers)</span></div>
+        <div class="metric-row"><span>Test coverage</span><span class="metric-val val-yellow">97%</span></div>
+        <div class="metric-row"><span>CI failures (static analysis)</span><span class="metric-val val-red">3 rounds</span></div>
+        <div class="metric-row"><span>Avoidable rework cycles</span><span class="metric-val val-red">3+</span></div>
+        <div class="metric-row"><span>Release pipeline failures</span><span class="metric-val val-yellow">1 (CI workflow branches)</span></div>
+        <div class="metric-row"><span>Agent invocations (est.)</span><span class="metric-val">~18–22</span></div>
+        <div class="metric-row"><span>Est. total tokens</span><span class="metric-val val-red">~1,000–1,300K</span></div>
+        <div class="metric-row"><span>Hit Pro rate limit?</span><span class="metric-val val-red">Yes (4h limit reached)</span></div>
+      </div>
+      <div class="v2-card">
+        <div class="ver-label v2-label">v0.2.0 — Feature Addition</div>
+        <div class="metric-row"><span>Deliverable</span><span class="metric-val">3 features + 482 tests + docs + release</span></div>
+        <div class="metric-row"><span>New source modules</span><span class="metric-val">2 new (logging_config, report_writer) + 5 modified</span></div>
+        <div class="metric-row"><span>Test coverage</span><span class="metric-val val-green">100%</span></div>
+        <div class="metric-row"><span>CI failures (static analysis)</span><span class="metric-val val-green">0</span></div>
+        <div class="metric-row"><span>Avoidable rework cycles</span><span class="metric-val val-yellow">1 (release pipeline)</span></div>
+        <div class="metric-row"><span>Release pipeline failures</span><span class="metric-val val-yellow">2 (PyInstaller + Windows PATH)</span></div>
+        <div class="metric-row"><span>Agent invocations</span><span class="metric-val">11 + 2 follow-ups</span></div>
+        <div class="metric-row"><span>Est. total tokens</span><span class="metric-val val-yellow">~750–920K</span></div>
+        <div class="metric-row"><span>Hit Pro rate limit?</span><span class="metric-val val-green">Not reported</span></div>
+      </div>
+    </div>
+    <div class="callout callout-purple">
+      <strong>⚠️ Comparability caveat</strong>
+      v0.1.0 was a greenfield project (all infrastructure + first implementation from scratch).
+      v0.2.0 added features to an existing codebase. Feature addition work packages are
+      inherently cheaper — less architecture, fewer fixtures, smaller modules. A fair token
+      comparison should account for this scope difference. The v0.2.0 savings are
+      <strong>partly structural</strong> (smaller scope) and <strong>partly process-driven</strong>
+      (fewer rework cycles). It is not possible to precisely separate these two factors with the
+      available data. Estimates marked (est.) throughout.
+    </div>
+  </section>
+
+  <!-- AGENT MATURITY COMPARISON -->
+  <section>
+    <h2>1 — Agent Maturity Comparison</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Agent</th>
+          <th>v0.1.0 Maturity</th>
+          <th>v0.2.0 Maturity</th>
+          <th>Direction</th>
+          <th>What changed</th>
+          <th>Top remaining gap</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Developer</strong></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-strong">Strong</span></td>
+          <td><span class="badge badge-up">↑ Improved</span></td>
+          <td>Mandatory lint gate at top of agent file eliminated 3 CI failure rounds → 0. ADR cross-check instruction followed; no signature violations.</td>
+          <td>No artifact (binary) verification step; no poetry constraint check before editing pyproject.toml</td>
+        </tr>
+        <tr>
+          <td><strong>Tester</strong></td>
+          <td><span class="badge badge-strong">Strong</span></td>
+          <td><span class="badge badge-strong">Strong</span></td>
+          <td><span class="badge badge-same">→ Maintained</span></td>
+          <td>Pre-handoff lint gate added (ruff + black on test files). TDD discipline maintained; red phases confirmed in all cycles.</td>
+          <td>No guidance for Bash-blocked commit fallback; quality gate agent token cost is high (~78K) due to 100% coverage target</td>
+        </tr>
+        <tr>
+          <td><strong>Architect</strong></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-same">→ Maintained</span></td>
+          <td>ADRs now include concrete Python function signatures (stubs). No signature violations in v0.2.0. ADR-008 embedded full spec file content.</td>
+          <td>Missed transitive dependency data file inspection for PyInstaller (rfc3987_syntax .lark file). No CI convention notes for Windows runners.</td>
+        </tr>
+        <tr>
+          <td><strong>Planner</strong></td>
+          <td><span class="badge badge-weak">Weak</span></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-up">↑ Improved</span></td>
+          <td>First proper standalone invocation. Produced 18-task plan with dependency graph, parallelization map, risk register, scope-lock per task.</td>
+          <td>Output verbosity too high (~32K tokens); no output length constraint in definition. File-conflict detection is reactive not proactive.</td>
+        </tr>
+        <tr>
+          <td><strong>Documentation Writer</strong></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-same">→ Maintained</span></td>
+          <td>URL placeholder issue fixed (correct GitHub username used). Documentation sections aligned with ADR content closely.</td>
+          <td>Bash-blocked commit pattern recurring (same as v0.1.0 content-filter block — different cause, same symptom). No fallback guidance.</td>
+        </tr>
+        <tr>
+          <td><strong>Reviewer</strong></td>
+          <td><span class="badge badge-strong">Strong</span></td>
+          <td><span class="badge badge-medium">Medium</span></td>
+          <td><span class="badge badge-down">↓ Underutilized</span></td>
+          <td>Agent definition unchanged (still Strong). But in v0.2.0 it was only used for static analysis verification — no full code review was done.</td>
+          <td>Planner did not schedule a code review pass. For feature work packages, a lightweight "spot review" of new modules should be default-on.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="card">
+      <h3>Overall Maturity Trajectory</h3>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; font-size:0.9rem;">
+        <div>
+          <div style="font-weight:700; margin-bottom:0.5rem;">v0.1.0 avg maturity by dimension</div>
+          <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-blue" style="width:84%"></div></div></div>
+          <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:73%"></div></div></div>
+          <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:70%"></div></div></div>
+          <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-red" style="width:39%"></div></div></div>
+        </div>
+        <div>
+          <div style="font-weight:700; margin-bottom:0.5rem;">v0.2.0 avg maturity by dimension</div>
+          <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-blue" style="width:88%"></div></div></div>
+          <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:83%"></div></div></div>
+          <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-green" style="width:86%"></div></div></div>
+          <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:52%"></div></div></div>
+        </div>
+      </div>
+      <p style="font-size:0.88rem; margin-top:0.75rem; margin-bottom:0;">
+        The biggest improvement is in <em>Quality gate definition</em> (+16pp) driven by the
+        mandatory lint gate. The most persistently weak dimension remains <em>Failure handling
+        guidance</em> — what agents do when tools are blocked, external resources fail, or
+        constraints conflict. This is the highest-ROI remaining investment for v0.3.0.
+      </p>
+    </div>
+  </section>
+
+  <!-- TOKEN EFFICIENCY COMPARISON -->
+  <section>
+    <h2>2 — Token Efficiency Comparison</h2>
+
+    <div class="callout callout-yellow">
+      <strong>⚠️ Measurement methodology</strong>
+      v0.1.0 token estimates are from the v0.1.0 evaluation report (estimated from session
+      transcript analysis — no direct measurements). v0.2.0 estimates combine reported
+      per-agent <code>usage.total_tokens</code> values (~415K measured) with estimated main
+      context overhead (~300–450K). All figures are order-of-magnitude estimates. The
+      structural scope difference (greenfield vs. feature addition) means a direct token
+      comparison overstates the efficiency gain from process improvements.
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Token sink</th>
+          <th class="v1-col">v0.1.0 (est.)</th>
+          <th class="v2-col">v0.2.0 (est.)</th>
+          <th>Change</th>
+          <th>Driver</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Cold-start context loading</td>
+          <td class="v1-col">~200K (14 agents × ~14K ea)</td>
+          <td class="v2-col">~80K (11 agents × ~7K ea via briefing)</td>
+          <td><span style="color:#166534; font-weight:700;">−60% ↓</span></td>
+          <td>agent-briefing.md replaced per-agent ADR reads</td>
+        </tr>
+        <tr>
+          <td>Static analysis failure + fix cycles</td>
+          <td class="v1-col">~80–100K (3 CI rounds)</td>
+          <td class="v2-col">~0 (0 CI rounds)</td>
+          <td><span style="color:#166534; font-weight:700;">−100% ↓</span></td>
+          <td>Mandatory lint gate enforced in agent definitions</td>
+        </tr>
+        <tr>
+          <td>Core implementation (new modules)</td>
+          <td class="v1-col">~350–450K (7 Tester+Dev pairs)</td>
+          <td class="v2-col">~170K (2 Tester+Dev pairs + CLI wiring)</td>
+          <td><span style="color:#166534; font-weight:700;">−55% ↓</span></td>
+          <td>Partly scope reduction (2 modules vs 8); partly parallelism</td>
+        </tr>
+        <tr>
+          <td>Quality gate (coverage closure)</td>
+          <td class="v1-col">~30K (97% target, few gaps)</td>
+          <td class="v2-col">~78K (100% target, 13 new tests)</td>
+          <td><span style="color:#dc2626; font-weight:700;">+160% ↑</span></td>
+          <td>100% coverage target is expensive; frozen-binary paths hard to test</td>
+        </tr>
+        <tr>
+          <td>Planning &amp; architecture</td>
+          <td class="v1-col">~120–160K (5 ADRs + diagrams + spec)</td>
+          <td class="v2-col">~70K (3 ADRs + planner)</td>
+          <td><span style="color:#166534; font-weight:700;">−45% ↓</span></td>
+          <td>Partly scope; planner was more verbose than ideal (+32K)</td>
+        </tr>
+        <tr>
+          <td>Release pipeline failure + fix</td>
+          <td class="v1-col">~20K (1 CI config fix)</td>
+          <td class="v2-col">~50K (2 pipeline failures + retag)</td>
+          <td><span style="color:#dc2626; font-weight:700;">+150% ↑</span></td>
+          <td>New failure mode: PyInstaller transitive deps + Windows PATH</td>
+        </tr>
+        <tr>
+          <td>Documentation &amp; orchestration</td>
+          <td class="v1-col">~200–300K</td>
+          <td class="v2-col">~200–300K</td>
+          <td>≈ Same</td>
+          <td>Main context overhead scales roughly with session length</td>
+        </tr>
+        <tr style="background:#f5f3ff; font-weight:700;">
+          <td>Estimated total</td>
+          <td class="v1-col">~1,000–1,300K</td>
+          <td class="v2-col">~750–920K</td>
+          <td><span style="color:#166534;">−20 to −30% ↓</span></td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Interpretation</h3>
+    <div class="comparison-grid">
+      <div class="card">
+        <strong style="color:#1b4332;">What improved token efficiency</strong>
+        <ul style="font-size:0.9rem; margin-top:0.5rem;">
+          <li><strong>Lint gate</strong> — eliminated ~80–100K of avoidable rework (biggest single fix)</li>
+          <li><strong>agent-briefing.md</strong> — ~120K saved on repeated context reads</li>
+          <li><strong>Planner parallelism</strong> — 4 tasks ran in parallel (smoke+PyInstaller, quality gate+docs)</li>
+          <li><strong>Shorter developer prompts</strong> — ADR-embedded spec content meant less prose needed in orchestrator prompts</li>
+        </ul>
+      </div>
+      <div class="card">
+        <strong style="color:#7c1d1d;">What worsened or didn't improve</strong>
+        <ul style="font-size:0.9rem; margin-top:0.5rem;">
+          <li><strong>Quality gate cost</strong> — 100% target cost 2.5× more than v0.1.0's 97% target</li>
+          <li><strong>Release pipeline</strong> — 2 failures vs 1 in v0.1.0; new failure mode (PyInstaller)</li>
+          <li><strong>Bash-blocked agents</strong> — 3 manual interventions required (new friction pattern)</li>
+          <li><strong>Planner verbosity</strong> — 32K for planning vs ~0K (inline) in v0.1.0 — net negative despite quality gain</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout callout-purple">
+      <strong>💡 Efficiency verdict</strong>
+      The ~20–30% reduction in estimated tokens represents <strong>genuine process improvement</strong>
+      (primarily lint gate + briefing file) partially offset by <strong>new friction</strong>
+      (Bash blocking, release pipeline, stricter coverage target). At current trajectory,
+      a further 15–20% reduction is achievable in v0.3.0 by: (1) adding Bash fallback
+      guidance, (2) fixing the ADR-008 transitive dep gap, (3) returning to 97% coverage
+      with pragmas, (4) constraining Planner output length. Combined these could bring a
+      similarly-scoped work package to ~600–700K tokens.
+    </div>
+  </section>
+
+  <!-- IMPROVEMENT OPPORTUNITIES -->
+  <section>
+    <h2>3 — Improvement Opportunities for Future Work Packages</h2>
+    <p>
+      Ordered by estimated token saving + implementation effort ratio. All ideas are
+      grounded in observed v0.1.0 and v0.2.0 session data.
+    </p>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">1</div>
+        <div class="idea-title">Add "Blocked Tool Fallback" to All Agent Definitions</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>What happened:</strong> 3 agents in v0.2.0 (and 1 in v0.1.0 via content filter)
+        could not complete their commit step due to tool permissions, requiring separate
+        follow-up agent invocations or manual orchestrator action.
+      </p>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>Fix:</strong> Add to all 6 agent definitions: <em>"If any required Bash
+        command is denied: (1) Output the exact commands in a fenced code block. (2) State
+        explicitly 'TASK INCOMPLETE — awaiting orchestrator to run the above commands.'
+        (3) Do not report the task as done."</em> This makes the failure mode graceful
+        instead of ambiguous.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~25–40K tokens/session</span>
+        <span class="impact-tag tag-quality">✅ No quality impact</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 30 min</span>
+        <span class="impact-tag tag-risk">🔄 Observed: 3× in v0.2.0</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">2</div>
+        <div class="idea-title">Architect: Add Transitive Dependency Data File Checklist for Binary ADRs</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>What happened:</strong> ADR-008 correctly identified <code>spdx-tools</code>
+        and <code>cyclonedx-bom</code> as hidden import risks but missed the transitive path
+        <code>jsonschema → rfc3987_syntax → *.lark</code>. This caused a build failure at
+        release time.
+      </p>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>Fix:</strong> Add to the Architect definition for any binary distribution ADR:
+        <em>"For each runtime dependency, check for non-Python data files. Run:
+        <code>pip show &lt;pkg&gt; | grep Location</code> and list any <code>*.json</code>,
+        <code>*.yaml</code>, <code>*.lark</code>, <code>*.txt</code> files that are opened
+        at runtime. Use <code>collect_data_files(pkg)</code> in the spec for each."</em>
+        Also add CI convention: Windows runners → <code>pip install poetry</code> +
+        <code>shell: bash</code> (snok/install-poetry known PATH issue).
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~30–50K tokens/release (2 pipeline runs → 1)</span>
+        <span class="impact-tag tag-quality">✅ First-pass binary works</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 1 hour</span>
+        <span class="impact-tag tag-risk">🔄 Observed: caused release failure in v0.2.0</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">3</div>
+        <div class="idea-title">Add Planner Output Length Constraint + Spot Review Decision Gate</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>What happened (verbosity):</strong> The Planner produced excellent content but
+        consumed ~32K tokens with extensive per-task prose. An 800-word output cap
+        (summary table + dependency list + top-5 risks) would deliver the same decisions at
+        ~12K tokens.
+      </p>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>What happened (review gap):</strong> No code review was scheduled in v0.2.0.
+        The Planner should include an explicit decision gate: <em>"Does this work package
+        add new core logic? → Schedule spot review (Reviewer reads new modules against ADRs,
+        ~20K tokens). Is it config/docs only? → Skip review."</em> A spot review in v0.2.0
+        might have caught the PyInstaller spec gap.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~20K tokens (Planner verbosity) + quality uplift from spot review</span>
+        <span class="impact-tag tag-quality">✅ Quality improved (review gate)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 45 min</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">4</div>
+        <div class="idea-title">Establish Coverage Policy: 97% + Named <code>pragma: no cover</code> Exceptions</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>What happened:</strong> The quality gate agent consumed ~78K tokens — 2.5×
+        the v0.1.0 quality gate — mostly chasing the last 3–4% of coverage over genuinely
+        hard-to-test branches (frozen binary paths, package metadata fallbacks).
+      </p>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>Fix:</strong> Establish a project policy: 97% minimum coverage with documented
+        <code># pragma: no cover</code> annotations for: (1) frozen binary (<code>sys._MEIPASS</code>)
+        branches, (2) <code>importlib.metadata</code> fallbacks, (3) any branch that would
+        require mocking stdlib internals. The Tester agent definition should include this
+        policy so it doesn't pursue 100% by default.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~20–30K tokens at quality gate</span>
+        <span class="impact-tag tag-quality">→ Quality: acceptable (exceptions documented)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 30 min (policy decision + 3 annotations)</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">5</div>
+        <div class="idea-title">Keep agent-briefing.md Current — Add a "Briefing Update" Step to Every Work Package</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>Observation:</strong> <code>agent-briefing.md</code> was the single highest-ROI
+        improvement from v0.1.0. It worked well in v0.2.0 because the Architect was explicitly
+        instructed to update it as part of the ADR tasks. However, in future work packages
+        where the Architect is not involved (e.g., a pure Developer task), the briefing could
+        become stale.
+      </p>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        <strong>Fix:</strong> Add to the Planner's task template a mandatory bookend task:
+        <em>"6.PRE — Review agent-briefing.md against current codebase; update module map,
+        function signatures, and ADR index if stale. Assign to Developer. 1 commit, no PR
+        needed. This task has no dependencies and runs before any other task."</em>
+        This ensures the briefing is always current at the start of each work package.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Saves: prevents cold-start drift in future sessions</span>
+        <span class="impact-tag tag-quality">✅ Quality improved (agents work from accurate signatures)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 30 min per work package start</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- MATURITY ROADMAP -->
+  <section>
+    <h2>4 — Recommended Agent Definition Updates Before v0.3.0</h2>
+    <p>Ordered by priority. All are small edits (15 min – 1 hour each).</p>
+
+    <table>
+      <thead>
+        <tr><th>Priority</th><th>Agent</th><th>Change</th><th>Expected impact</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>P1</strong></td>
+          <td>All (6 agents)</td>
+          <td>Add "Blocked Bash Fallback" section</td>
+          <td>Eliminate 3 follow-up invocations per session (~25–40K tokens)</td>
+        </tr>
+        <tr>
+          <td><strong>P1</strong></td>
+          <td>Architect</td>
+          <td>Add transitive data file checklist for binary distribution ADRs + Windows CI convention note</td>
+          <td>Eliminate release pipeline rework (~30–50K tokens)</td>
+        </tr>
+        <tr>
+          <td><strong>P2</strong></td>
+          <td>Planner</td>
+          <td>Add output length constraint (800-word cap) + spot review decision gate</td>
+          <td>~20K tokens saved per planning pass; code review quality gate restored</td>
+        </tr>
+        <tr>
+          <td><strong>P2</strong></td>
+          <td>Tester</td>
+          <td>Add coverage policy: 97% minimum, pragma:no cover for frozen-binary paths</td>
+          <td>~20–30K tokens saved at quality gate</td>
+        </tr>
+        <tr>
+          <td><strong>P3</strong></td>
+          <td>Developer</td>
+          <td>Add binary artifact verification step: "if task produces a binary, run it with --version before marking done"</td>
+          <td>Catch PyInstaller-class issues before CI</td>
+        </tr>
+        <tr>
+          <td><strong>P3</strong></td>
+          <td>Developer</td>
+          <td>Add poetry constraint check: "run poetry add --dry-run before editing pyproject.toml"</td>
+          <td>Prevent constraint conflicts requiring manual fix</td>
+        </tr>
+        <tr>
+          <td><strong>P3</strong></td>
+          <td>Planner</td>
+          <td>Add briefing freshness check as mandatory first task (6.PRE)</td>
+          <td>Prevent agent-briefing.md drift across work packages</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- TRAJECTORY -->
+  <section>
+    <h2>5 — Efficiency Trajectory Projection</h2>
+
+    <div class="card">
+      <p>
+        If the P1 and P2 improvements above are implemented before the next work package,
+        the estimated token budget for a similarly-scoped feature-addition session
+        (2–3 new modules, comparable complexity) would be:
+      </p>
+      <table>
+        <thead>
+          <tr><th>Session</th><th>Est. tokens</th><th>Key driver of change</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>v0.1.0 (baseline)</td>
+            <td>~1,000–1,300K</td>
+            <td>Greenfield + lint failures + no briefing + no Planner</td>
+          </tr>
+          <tr>
+            <td>v0.2.0 (current)</td>
+            <td>~750–920K</td>
+            <td>Lint gate + briefing + Planner; new friction: Bash blocks, release failures</td>
+          </tr>
+          <tr>
+            <td>v0.3.0 (projected, P1+P2 fixes applied)</td>
+            <td class="val-green"><strong>~580–720K (est.)</strong></td>
+            <td>Bash fallback (−35K) + ADR-008 fix (−40K) + coverage policy (−25K) + Planner cap (−20K)</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="uncertain" style="margin-top:0.5rem;">
+        Projection assumes similar work package scope and no new unforeseen friction patterns.
+        The main unknown is orchestration context growth — as the codebase grows, agents read
+        larger files, and main context tokens increase proportionally. Context compression (e.g.,
+        summarizing completed phase outputs) could become relevant beyond v0.3.0.
+      </p>
+    </div>
+  </section>
+
+  <div class="report-footer">
+    <p>
+      Generated by Claude Sonnet 4.6 on 2026-04-09.<br/>
+      Individual session reports: <a href="workflow-evaluation-report.html">v0.1.0 Evaluation</a> &nbsp;|&nbsp;
+      <a href="workflow-evaluation-report_v0.2.0.html">v0.2.0 Evaluation</a><br/>
+      Token estimates are derived from session metadata and known Claude output rates — treat as indicative, not precise.
+      Scope difference between v0.1.0 (greenfield) and v0.2.0 (feature addition) is a confounding factor in all comparisons.
+    </p>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/workflow-evaluation-report_v0.2.0.html
+++ b/docs/workflow-evaluation-report_v0.2.0.html
@@ -1,0 +1,784 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Workflow Evaluation — sbom-validator v0.2.0 Session</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 15px; line-height: 1.65; color: #1a1a2e; background: #f7f8fc;
+    }
+    a { color: #3b5bdb; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .page { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
+
+    .report-header {
+      background: linear-gradient(135deg, #1b4332 0%, #2d6a4f 100%);
+      color: white; padding: 2.5rem 2rem; border-radius: 12px; margin-bottom: 2rem;
+    }
+    .report-header h1 { font-size: 1.9rem; font-weight: 700; margin-bottom: 0.4rem; }
+    .report-header .meta { font-size: 0.9rem; opacity: 0.82; margin-top: 0.6rem; }
+    .report-header .meta span { margin-right: 1.6rem; }
+
+    section { margin-bottom: 2.5rem; }
+    h2 { font-size: 1.3rem; font-weight: 700; color: #1b4332; border-left: 5px solid #2d6a4f; padding-left: 0.75rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.05rem; font-weight: 600; color: #2c5f4a; margin: 1.2rem 0 0.5rem; }
+    p { margin-bottom: 0.75rem; }
+
+    .card { background: white; border-radius: 10px; padding: 1.4rem 1.6rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); margin-bottom: 1rem; }
+    .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+
+    .badge { display: inline-block; padding: 0.22em 0.75em; border-radius: 20px; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.02em; text-transform: uppercase; }
+    .badge-strong  { background: #d3f9d8; color: #1a6b2f; }
+    .badge-medium  { background: #fff3bf; color: #7c5000; }
+    .badge-weak    { background: #ffe3e3; color: #8b0000; }
+    .badge-high    { background: #ffe3e3; color: #8b0000; }
+    .badge-med     { background: #fff3bf; color: #7c5000; }
+    .badge-low     { background: #d3f9d8; color: #1a6b2f; }
+    .badge-improved { background: #d0ebff; color: #1c4f8a; }
+    .badge-partial  { background: #fff3bf; color: #7c5000; }
+    .badge-missed   { background: #ffe3e3; color: #8b0000; }
+
+    table { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin: 0.75rem 0 1rem; }
+    th { background: #d8f3dc; color: #1b4332; font-weight: 700; text-align: left; padding: 0.55rem 0.8rem; }
+    td { padding: 0.5rem 0.8rem; border-bottom: 1px solid #e8ecf5; vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: #f0faf2; }
+
+    ul, ol { padding-left: 1.4rem; margin-bottom: 0.75rem; }
+    li { margin-bottom: 0.35rem; }
+
+    .callout { border-radius: 8px; padding: 1rem 1.25rem; margin: 1rem 0; border-left: 4px solid; font-size: 0.92rem; }
+    .callout-blue   { background: #e7f5ff; border-color: #3b5bdb; }
+    .callout-yellow { background: #fff9db; border-color: #f59f00; }
+    .callout-red    { background: #fff5f5; border-color: #e03131; }
+    .callout-green  { background: #ebfbee; border-color: #2f9e44; }
+    .callout strong { display: block; margin-bottom: 0.3rem; }
+
+    .progress-wrap { background: #e8ecf5; border-radius: 8px; height: 10px; margin: 0.3rem 0 0.8rem; overflow: hidden; }
+    .progress-bar  { height: 100%; border-radius: 8px; }
+    .bar-green  { background: #40c057; }
+    .bar-yellow { background: #fab005; }
+    .bar-red    { background: #fa5252; }
+    .bar-blue   { background: #339af0; }
+
+    .idea-card { background: white; border-radius: 10px; padding: 1.2rem 1.5rem; margin-bottom: 0.9rem; box-shadow: 0 1px 4px rgba(0,0,0,0.08); border-left: 5px solid #2d6a4f; }
+    .idea-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+    .idea-num { background: #2d6a4f; color: white; width: 2rem; height: 2rem; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 0.9rem; flex-shrink: 0; }
+    .idea-title { font-weight: 700; font-size: 1.02rem; color: #1b4332; }
+    .impact-row { display: flex; gap: 1rem; margin-top: 0.6rem; font-size: 0.82rem; flex-wrap: wrap; }
+    .impact-tag { padding: 0.15em 0.6em; border-radius: 4px; font-weight: 600; }
+    .tag-token   { background: #ffe8cc; color: #953b00; }
+    .tag-quality { background: #d3f9d8; color: #1a6b2f; }
+    .tag-effort  { background: #e7f5ff; color: #1565c0; }
+
+    .gap-row { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.8rem; border-bottom: 1px solid #e8ecf5; font-size: 0.9rem; }
+    .gap-row:last-child { border-bottom: none; }
+
+    .report-footer { margin-top: 3rem; padding-top: 1.2rem; border-top: 1px solid #dde2f0; font-size: 0.82rem; color: #6b7280; }
+    .uncertain { font-style: italic; color: #6b7280; font-size: 0.88rem; }
+    code { background: #f1f3f9; padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.87em; }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <!-- HEADER -->
+  <div class="report-header">
+    <h1>Human-in-the-Loop AI Workflow — v0.2.0 Session Evaluation</h1>
+    <p style="opacity:0.88; margin-top:0.5rem; max-width:660px;">
+      Analysis of the multi-agent Specification Driven Development session that delivered
+      <strong>sbom-validator v0.2.0</strong>: structured logging, HTML/JSON report generation,
+      and standalone binary distribution for Windows and Linux.
+    </p>
+    <div class="meta">
+      <span>📅 Session date: 2026-04-08</span>
+      <span>🚀 Deliverable: sbom-validator v0.2.0</span>
+      <span>🤖 Model: Claude Sonnet 4.6 (Pro subscription)</span>
+    </div>
+  </div>
+
+  <!-- EXECUTIVE SUMMARY -->
+  <section>
+    <h2>Executive Summary</h2>
+    <div class="card">
+      <p>
+        The session delivered all three user stories — <strong>structured logging</strong>
+        (<code>--log-level</code>), <strong>HTML/JSON report generation</strong>
+        (<code>--report-dir</code>), and <strong>standalone binaries</strong> for Windows
+        and Linux — across 11 agent invocations, with zero static-analysis failures
+        (<code>ruff</code>, <code>black</code>, <code>mypy</code>) and 100% test coverage
+        (482 tests, up from 358 at 97%).
+      </p>
+      <p>
+        The workflow was <strong>effective and noticeably more efficient</strong> than v0.1.0.
+        Four of the five improvement ideas from the previous evaluation were partially or fully
+        implemented. The mandatory lint gate eliminated the three CI failure cycles that cost
+        ~80–100K tokens in v0.1.0. The agent-briefing.md file reduced cold-start context loading.
+        The Planner agent was properly invoked for the first time.
+      </p>
+      <p>
+        The main new friction point was the <strong>release pipeline</strong> — two distinct
+        failures (PyInstaller missing transitive data files on Linux; Poetry not found on
+        Windows) required a post-release hotfix. This is a gap in the Architect's ADR-008
+        scope and in the Developer's binary verification step.
+      </p>
+      <div style="display:flex; gap:2rem; flex-wrap:wrap; margin-top:1rem;">
+        <div>
+          <div style="font-size:0.8rem; color:#6b7280; margin-bottom:0.2rem;">Agent Maturity (avg)</div>
+          <div style="font-size:1.8rem; font-weight:800; color:#2d6a4f;">Medium–Strong</div>
+        </div>
+        <div>
+          <div style="font-size:0.8rem; color:#6b7280; margin-bottom:0.2rem;">Token Efficiency</div>
+          <div style="font-size:1.8rem; font-weight:800; color:#fab005;">Medium</div>
+        </div>
+        <div>
+          <div style="font-size:0.8rem; color:#6b7280; margin-bottom:0.2rem;">Output Quality</div>
+          <div style="font-size:1.8rem; font-weight:800; color:#40c057;">High</div>
+        </div>
+        <div>
+          <div style="font-size:0.8rem; color:#6b7280; margin-bottom:0.2rem;">Avoidable Rework</div>
+          <div style="font-size:1.8rem; font-weight:800; color:#fab005;">1 cycle</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SECTION 0: GAP CLOSURE FROM v0.1.0 -->
+  <section>
+    <h2>0 — v0.1.0 Gap Closure Assessment</h2>
+    <p>
+      The v0.1.0 evaluation identified 5 improvement ideas. This section scores how
+      thoroughly each was addressed in the v0.2.0 session.
+    </p>
+    <div class="card">
+      <div class="gap-row">
+        <span class="badge badge-improved">✓ Addressed</span>
+        <div>
+          <strong>Idea 1 — Compact "Project Briefing" file</strong><br/>
+          <span style="font-size:0.88rem;">
+            <code>docs/agent-briefing.md</code> was created after v0.1.0 and used in this session.
+            The Architect updated it as part of ADR writing. Developer and Tester agents were
+            explicitly directed to read it. Cold-start reads of 5 ADRs + normalized-model.md
+            were replaced by a single briefing read in most agent prompts.
+            <span class="uncertain">Estimated saving vs v0.1.0: ~120–150K tokens (est.) — this was the highest-impact fix.</span>
+          </span>
+        </div>
+      </div>
+      <div class="gap-row">
+        <span class="badge badge-improved">✓ Addressed</span>
+        <div>
+          <strong>Idea 2 — Mandatory pre-handoff lint gate</strong><br/>
+          <span style="font-size:0.88rem;">
+            The Developer and Tester agent definitions both now have a mandatory
+            <code>ruff + black + mypy</code> block at the top of the file, formatted as
+            a non-negotiable gate. Result: zero static-analysis failures in this session
+            (vs. 3 CI failure rounds in v0.1.0). This was the most directly measurable
+            improvement.
+          </span>
+        </div>
+      </div>
+      <div class="gap-row">
+        <span class="badge badge-improved">✓ Addressed</span>
+        <div>
+          <strong>Idea 3 — Concrete type signatures (runnable stubs) in ADRs</strong><br/>
+          <span style="font-size:0.88rem;">
+            ADR-006, 007, and 008 all included concrete Python function signatures.
+            ADR-007 specified <code>write_reports(result: ValidationResult, report_dir: Path) -&gt; tuple[Path, Path]</code>
+            verbatim. No signature violations occurred in implementation — the CRITICAL findings
+            from v0.1.0 (R-04/R-05 parser signature mismatch) were not repeated.
+          </span>
+        </div>
+      </div>
+      <div class="gap-row">
+        <span class="badge badge-improved">✓ Addressed</span>
+        <div>
+          <strong>Idea 4 — Targeted test runs during development</strong><br/>
+          <span style="font-size:0.88rem;">
+            Developer agent definition now instructs targeted <code>pytest tests/unit/test_&lt;module&gt;.py</code>
+            runs during implementation, with full suite only at phase end. Agents followed this
+            pattern in v0.2.0. Estimated reduction: 5–7 avoidable full-suite runs eliminated.
+          </span>
+        </div>
+      </div>
+      <div class="gap-row">
+        <span class="badge badge-partial">~ Partial</span>
+        <div>
+          <strong>Idea 5 — Planner agent actually invoked as standalone agent</strong><br/>
+          <span style="font-size:0.88rem;">
+            The Planner was invoked for the first time as a proper standalone agent and produced
+            an excellent 18-task plan with dependency graph and risk register. However, the
+            Planner output was very verbose (~31K tokens consumed) and the plan document itself
+            was longer than necessary. Token-budget awareness guidance in the Planner definition
+            (introduced after v0.1.0) helped but did not fully constrain output length.
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SECTION 1: AGENT MATURITY -->
+  <section>
+    <h2>1 — Agent Maturity Benchmark (v0.2.0)</h2>
+    <p>
+      Agents are evaluated on: <em>Role clarity</em>, <em>Context specificity</em>,
+      <em>Quality gate definition</em>, <em>Failure handling guidance</em>.
+      Maturity: <span class="badge badge-strong">Strong</span>
+      <span class="badge badge-medium">Medium</span>
+      <span class="badge badge-weak">Weak</span>.
+    </p>
+
+    <!-- DEVELOPER -->
+    <div class="card">
+      <div style="display:flex; align-items:center; gap:0.8rem; margin-bottom:0.6rem;">
+        <span style="font-size:1.2rem;">👨‍💻</span>
+        <strong style="font-size:1.05rem;">Developer Agent</strong>
+        <span class="badge badge-strong">Strong</span>
+        <span style="font-size:0.82rem; color:#2d6a4f; font-weight:600;">↑ Upgraded from Medium</span>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.4rem; font-size:0.88rem; margin-bottom:0.75rem;">
+        <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:90%"></div></div></div>
+        <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:88%"></div></div></div>
+        <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-green" style="width:92%"></div></div></div>
+        <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:55%"></div></div></div>
+      </div>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>What improved:</strong> The mandatory lint gate at the top of the agent file
+        worked exactly as designed — zero ruff/black/mypy failures across all four Developer
+        invocations. The ADR cross-check instruction ("read docs/agent-briefing.md before
+        writing any code, verify signatures match") was followed; no signature violations
+        occurred. Targeted test run guidance was respected.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>Remaining gap:</strong> The Developer agent for PyInstaller (9.C2) could not
+        do a test binary build locally (Bash tool was blocked mid-session, requiring manual
+        orchestrator intervention for commits). More critically, the agent did not attempt
+        even a simple <code>pyinstaller --help</code> dry-run or inspect the dependency tree
+        for non-Python data assets — which would have surfaced the <code>rfc3987_syntax</code>
+        missing <code>.lark</code> file before release.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Suggested fix:</strong> Add a "build artifact verification" step to the agent
+        definition for tasks involving PyInstaller or other build tools:
+        <em>"If the task produces a binary or compiled artifact, run it with <code>--version</code>
+        and one real fixture before marking done."</em>
+      </p>
+    </div>
+
+    <!-- TESTER -->
+    <div class="card">
+      <div style="display:flex; align-items:center; gap:0.8rem; margin-bottom:0.6rem;">
+        <span style="font-size:1.2rem;">🧪</span>
+        <strong style="font-size:1.05rem;">Tester Agent</strong>
+        <span class="badge badge-strong">Strong</span>
+        <span style="font-size:0.82rem; color:#888; font-weight:600;">→ Maintained</span>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.4rem; font-size:0.88rem; margin-bottom:0.75rem;">
+        <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:90%"></div></div></div>
+        <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:85%"></div></div></div>
+        <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-green" style="width:88%"></div></div></div>
+        <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:60%"></div></div></div>
+      </div>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>Strong performance:</strong> TDD discipline maintained cleanly across two
+        complete red→green cycles (logging: 34 tests, reports: 57 tests + 11 CLI tests).
+        Red phases confirmed before each Developer handoff. The quality gate agent (Phase 10)
+        identified 13 uncovered branches and wrote targeted tests to reach 100% coverage.
+        No ruff/black issues in test output (mandatory lint gate followed).
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>New observation:</strong> The quality gate agent consumed ~78K tokens — the
+        heaviest single-agent spend in the session. This was driven by needing to read all test
+        files, identify uncovered branches across 7 modules, and write 13 targeted tests. This
+        is partly unavoidable but partly due to the coverage target being set at 100% (up from
+        97% in v0.1.0). The 3% gap required finding and testing very specific exception paths.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Remaining gap:</strong> Smoke test agent (9.C1) was blocked from committing
+        (Bash permission issue) — required a separate manual intervention. The Tester definition
+        has no guidance on handling tool permission failures mid-task.
+      </p>
+    </div>
+
+    <!-- ARCHITECT -->
+    <div class="card">
+      <div style="display:flex; align-items:center; gap:0.8rem; margin-bottom:0.6rem;">
+        <span style="font-size:1.2rem;">🏛️</span>
+        <strong style="font-size:1.05rem;">Architect Agent</strong>
+        <span class="badge badge-medium">Medium</span>
+        <span style="font-size:0.82rem; color:#888; font-weight:600;">→ Maintained</span>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.4rem; font-size:0.88rem; margin-bottom:0.75rem;">
+        <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:85%"></div></div></div>
+        <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:82%"></div></div></div>
+        <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-green" style="width:80%"></div></div></div>
+        <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:45%"></div></div></div>
+      </div>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>What worked well:</strong> All three ADRs included concrete function signatures
+        (the gap from v0.1.0). ADR-007 specified the exact JSON schema keys. ADR-008 embedded
+        the full PyInstaller spec content — a significant improvement that allowed Developer 9.C2
+        to treat the ADR as a direct implementation blueprint.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>Key failure — ADR-008 scope gap:</strong> The ADR called out <code>spdx-tools</code>
+        and <code>cyclonedx-bom</code> as hidden import risks, but missed the transitive path:
+        <code>jsonschema</code> → <code>rfc3987_syntax</code> → <code>syntax_rfc3987.lark</code>
+        (a non-Python data file). PyInstaller bundles Python code automatically but not data files
+        from transitive dependencies unless explicitly listed. This is a known PyInstaller failure
+        mode that the Architect did not check for.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Suggested fix:</strong> Add to the Architect agent definition:
+        <em>"For ADRs involving frozen binary distribution: check each runtime dependency for
+        non-Python data files by running <code>pip show &lt;pkg&gt;</code> and inspecting the
+        package directory for <code>*.json</code>, <code>*.lark</code>, <code>*.yaml</code>
+        or similar assets. Use <code>collect_data_files()</code> for any package with such assets."</em>
+      </p>
+    </div>
+
+    <!-- PLANNER -->
+    <div class="card">
+      <div style="display:flex; align-items:center; gap:0.8rem; margin-bottom:0.6rem;">
+        <span style="font-size:1.2rem;">📋</span>
+        <strong style="font-size:1.05rem;">Planner Agent</strong>
+        <span class="badge badge-medium">Medium</span>
+        <span style="font-size:0.82rem; color:#2d6a4f; font-weight:600;">↑ Upgraded from Weak</span>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.4rem; font-size:0.88rem; margin-bottom:0.75rem;">
+        <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:85%"></div></div></div>
+        <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:75%"></div></div></div>
+        <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:65%"></div></div></div>
+        <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:50%"></div></div></div>
+      </div>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>What improved:</strong> First actual invocation as a standalone agent. Produced
+        18 tasks with task IDs, dependency graph, parallelization map, risks register, and
+        scope-lock output per task. The plan correctly identified the 3 ADR sign-off gate and
+        the critical path. Token-budget awareness (cap at 4 parallel tracks) was respected.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>Remaining gap — output verbosity:</strong> The plan consumed ~32K tokens and
+        produced far more prose than an orchestrator needs. A concise summary table + dependency
+        graph would serve the same purpose at 30–40% of the token cost. The Planner definition
+        needs an explicit output length constraint.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Remaining gap — file conflict detection:</strong> The plan noted that 6.A1 and
+        6.A2 both modify <code>agent-briefing.md</code> (a merge conflict risk) but the proposed
+        resolution was "assign to the same agent invocation or sequence them." In practice, the
+        Architect was given both tasks together, which worked, but the Planner's guidance here
+        was reactive not proactive.
+      </p>
+    </div>
+
+    <!-- DOCUMENTATION WRITER -->
+    <div class="card">
+      <div style="display:flex; align-items:center; gap:0.8rem; margin-bottom:0.6rem;">
+        <span style="font-size:1.2rem;">📝</span>
+        <strong style="font-size:1.05rem;">Documentation Writer Agent</strong>
+        <span class="badge badge-medium">Medium</span>
+        <span style="font-size:0.82rem; color:#888; font-weight:600;">→ Maintained</span>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.4rem; font-size:0.88rem; margin-bottom:0.75rem;">
+        <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:85%"></div></div></div>
+        <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:82%"></div></div></div>
+        <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:72%"></div></div></div>
+        <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:45%"></div></div></div>
+      </div>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>What improved:</strong> The <code>your-org</code> placeholder URL issue from
+        v0.1.0 was fixed in the user-guide update (the agent used the correct <code>SuceaCosmin</code>
+        GitHub URL). Documentation sections matched the actual ADR content closely. CHANGELOG
+        followed the existing format.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Remaining gap:</strong> Bash tool was blocked for git commit — the agent produced
+        output but could not complete the commit step, requiring manual intervention from the
+        orchestrator. This is a recurring failure mode (also hit by Developer 9.C2 and Tester 9.C1).
+        The agent definition has no guidance for this scenario.
+      </p>
+    </div>
+
+    <!-- REVIEWER -->
+    <div class="card">
+      <div style="display:flex; align-items:center; gap:0.8rem; margin-bottom:0.6rem;">
+        <span style="font-size:1.2rem;">🔍</span>
+        <strong style="font-size:1.05rem;">Reviewer Agent</strong>
+        <span class="badge badge-medium">Medium</span>
+        <span style="font-size:0.82rem; color:#e03131; font-weight:600;">↓ Effectively downgraded</span>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.4rem; font-size:0.88rem; margin-bottom:0.75rem;">
+        <div>Role clarity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:90%"></div></div></div>
+        <div>Context specificity<div class="progress-wrap"><div class="progress-bar bar-green" style="width:85%"></div></div></div>
+        <div>Quality gate definition<div class="progress-wrap"><div class="progress-bar bar-green" style="width:90%"></div></div></div>
+        <div>Failure handling guidance<div class="progress-wrap"><div class="progress-bar bar-yellow" style="width:60%"></div></div></div>
+      </div>
+      <p style="font-size:0.9rem; margin-bottom:0.5rem;">
+        <strong>Critical observation:</strong> The Reviewer agent was only used for static
+        analysis verification (task 10.D2) in v0.2.0. There was no dedicated architecture/code
+        review pass equivalent to Phase 4 in v0.1.0 (which found 13 findings including 3
+        CRITICAL bugs). This is a <strong>workflow regression</strong>. The agent definition is
+        Strong, but the workflow did not use it at its designed scope.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Why this matters:</strong> The v0.2.0 codebase was smaller and the features
+        were lower-risk (no new data model changes), which may justify skipping a full review
+        this iteration. But the Planner should explicitly gate on whether a full code review
+        is needed per work package, rather than defaulting to "no review." A lightweight
+        review (spot-checking new modules against ADRs) would cost ~20K tokens and could
+        catch issues like the frozen-binary data-file gap before release.
+      </p>
+    </div>
+
+    <!-- Summary Table -->
+    <div class="card">
+      <h3>Summary Table</h3>
+      <table>
+        <thead>
+          <tr><th>Agent</th><th>v0.1.0</th><th>v0.2.0</th><th>Change</th><th>Top remaining gap</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Developer</td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td><span class="badge badge-strong">Strong</span></td>
+            <td>↑ Lint gate enforcement</td>
+            <td>No binary artifact verification step</td>
+          </tr>
+          <tr>
+            <td>Tester</td>
+            <td><span class="badge badge-strong">Strong</span></td>
+            <td><span class="badge badge-strong">Strong</span></td>
+            <td>→ Maintained</td>
+            <td>No guidance for Bash-blocked commit fallback</td>
+          </tr>
+          <tr>
+            <td>Architect</td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td>→ Maintained (stubs improved, transitive deps gap remains)</td>
+            <td>Transitive dependency data file inspection for PyInstaller</td>
+          </tr>
+          <tr>
+            <td>Planner</td>
+            <td><span class="badge badge-weak">Weak</span></td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td>↑ First real invocation, good output</td>
+            <td>Output too verbose; no length constraint</td>
+          </tr>
+          <tr>
+            <td>Documentation Writer</td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td>→ URL placeholder fixed; Bash-blocked pattern recurs</td>
+            <td>No guidance for tool permission failures</td>
+          </tr>
+          <tr>
+            <td>Reviewer</td>
+            <td><span class="badge badge-strong">Strong</span></td>
+            <td><span class="badge badge-medium">Medium</span></td>
+            <td>↓ Not used at full scope (only static analysis)</td>
+            <td>Planner should decide per-WP whether full review is needed</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- SECTION 2: REPETITIVE TASKS -->
+  <section>
+    <h2>2 — Most Repetitive Tasks (v0.2.0)</h2>
+
+    <table>
+      <thead>
+        <tr><th>#</th><th>Repetitive Task</th><th>Occurrences</th><th>Avoidable?</th><th>Rational</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td><strong>Manual orchestrator intervention for blocked Bash commits</strong> — three agents (smoke test tester 9.C1, PyInstaller developer 9.C2, documentation writer 10.D3) could write files but not commit them</td>
+          <td>3× in one session</td>
+          <td><span class="badge badge-high">Yes</span></td>
+          <td>Each instance required the orchestrator to spawn a correction agent or run manual git commands. This is a workflow gap: agents have no fallback instruction for when Bash is restricted. Suggested fix: each agent definition should include a "if Bash commit is blocked" step that outputs the exact commands for the orchestrator to run manually.</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td><strong>Release pipeline re-run</strong> — full 2-job CI build triggered twice for v0.2.0 due to two separate failures</td>
+          <td>2 pipeline runs (each ~1–2 min CI + fix time)</td>
+          <td><span class="badge badge-high">Mostly</span></td>
+          <td>The rfc3987_syntax data file issue could have been caught by a local test build. The Windows Poetry PATH issue could have been caught by referencing the snok/install-poetry known issues documentation. Both were ADR-008 gaps. A single "validate the spec locally before writing the CI workflow" step would have caught at least one of the two.</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td><strong>Quality gate coverage pass</strong> — Phase 10 tester wrote 13 tests to close coverage from 96% to 100%</td>
+          <td>1 pass (but consumed ~78K tokens)</td>
+          <td><span class="badge badge-med">Partially</span></td>
+          <td>Some uncovered branches (PyInstaller <code>_MEIPASS</code> path, <code>PackageNotFoundError</code> fallback) are genuinely hard to test during implementation. Others (validator exception paths) should have been caught by the Developer's own test coverage check. The coverage target of 100% (up from 97%) is strict and added ~20K tokens of incremental cost.</td>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td><strong>Poetry lock constraint fix</strong> — PyInstaller constraint <code>&gt;=6.0</code> conflicted with Python <code>&lt;4.0</code> bound; required manual pyproject.toml edit and re-lock</td>
+          <td>1× (manual fix required)</td>
+          <td><span class="badge badge-high">Yes</span></td>
+          <td>The Developer agent wrote the PyInstaller dependency without checking the constraint compatibility in the existing pyproject.toml. Running <code>poetry add pyinstaller --dry-run</code> before editing would have surfaced this. A "check poetry constraint compatibility before editing pyproject.toml" instruction should be added to the Developer definition.</td>
+        </tr>
+        <tr>
+          <td>5</td>
+          <td><strong>Agent-briefing.md concurrent modification</strong> — Architect wrote ADR-006 and ADR-007 sequentially to avoid merge conflicts on the shared briefing file</td>
+          <td>2× serialized tasks that could have been fully parallel</td>
+          <td><span class="badge badge-med">Partially</span></td>
+          <td>The Planner correctly flagged the conflict but resolved it by serializing. A better resolution: have one of the two ADR agents own all agent-briefing.md updates (the other just notes what it would add). This would have allowed true parallelism for the ADR phase.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- SECTION 3: TOKEN USAGE -->
+  <section>
+    <h2>3 — Token Usage Evaluation</h2>
+
+    <div class="callout callout-yellow">
+      <strong>⚠️ Uncertainty note</strong>
+      Agent-level token counts are taken from the <code>usage.total_tokens</code> field
+      reported at the end of each agent invocation (visible in session metadata). Main
+      orchestration context (the primary conversation window carrying all tool results,
+      user messages, and my responses) is estimated — no direct measurement is available.
+      Sub-agent tokens do not fully account for input context (files read, tool results)
+      vs. output tokens. Treat totals as order-of-magnitude estimates.
+    </div>
+
+    <h3>Per-Agent Token Consumption (measured from session)</h3>
+    <table>
+      <thead>
+        <tr><th>Agent / Task</th><th>Tokens (reported)</th><th>Notes</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Planner — work package breakdown</td><td>31,957</td><td>High for planning — output very verbose</td></tr>
+        <tr><td>Architect — ADRs 006/007/008 + agent-briefing update</td><td>37,570</td><td>Good — 4 deliverables in one pass</td></tr>
+        <tr><td>Tester — logging red phase (7.A1)</td><td>44,111</td><td>Reasonable for 34 new tests + existing file read</td></tr>
+        <tr><td>Developer — logging green phase (7.A2)</td><td>38,263</td><td>Efficient — lint gate self-enforced</td></tr>
+        <tr><td>Tester — report writer red phase (8.B1 + 8.B3)</td><td>44,234</td><td>Reasonable for 57+11 tests</td></tr>
+        <tr><td>Developer — report writer green phase (8.B2 + 8.B4)</td><td>39,870</td><td>Efficient — no rework needed</td></tr>
+        <tr><td>Tester — smoke test script (9.C1)</td><td>18,778</td><td>Partial — Bash blocked, needed follow-up</td></tr>
+        <tr><td>Developer — PyInstaller spec + release workflow (9.C2 + 9.C3)</td><td>25,806</td><td>Partial — Bash blocked mid-task</td></tr>
+        <tr><td>Tester — smoke test commit fix (follow-up)</td><td>~10,831</td><td>Avoidable overhead from Bash block</td></tr>
+        <tr><td>Tester/Reviewer — quality gate (10.D1 + 10.D2)</td><td>77,975</td><td>Heaviest agent — 13 new tests to hit 100%</td></tr>
+        <tr><td>Documentation Writer (10.D3 + 10.D4)</td><td>45,843</td><td>Good — 4 files in one pass</td></tr>
+        <tr><td><strong>Sub-agent total</strong></td><td><strong>~415K</strong></td><td></td></tr>
+        <tr><td>Main orchestration context (est.)</td><td>~300–450K (est.)</td><td>Carries all tool results, user messages, responses across 12 turns</td></tr>
+        <tr><td>Release pipeline debug + fix (2 rounds)</td><td>~30–50K (est.)</td><td>Read logs, fix spec + workflow, manual commits</td></tr>
+        <tr><td><strong>Estimated session total</strong></td><td><strong>~750K–920K (est.)</strong></td><td></td></tr>
+      </tbody>
+    </table>
+
+    <h3>Verdict</h3>
+    <div class="callout callout-blue">
+      <strong>🔵 Medium efficiency — improved from v0.1.0 Low–Medium</strong>
+      <p style="margin-top:0.4rem;">
+        Estimated total tokens (~750K–920K) represent a <strong>20–30% reduction</strong>
+        from v0.1.0 (~1,000K–1,300K). The primary drivers of savings:
+      </p>
+      <ul style="margin-top:0.4rem; font-size:0.92rem;">
+        <li><strong>Lint gate enforcement</strong> — eliminated ~80–100K tokens of CI failure + fix cycles</li>
+        <li><strong>agent-briefing.md</strong> — reduced cold-start context loading across all agent invocations</li>
+        <li><strong>Planner-driven parallelization</strong> — multiple phases ran in parallel (smoke test + PyInstaller developer; quality gate + documentation writer)</li>
+      </ul>
+      <p style="margin-top:0.4rem;">
+        The largest remaining waste is the <strong>quality gate agent (~78K tokens)</strong>
+        and the <strong>release pipeline failure</strong> (~2 full build runs + fix cycle, ~50K tokens est.).
+        Combined these account for ~130K tokens that could be reduced with better ADR-008
+        scope and a lower coverage target (97% vs 100% would have saved ~15K tokens at the
+        quality gate stage).
+      </p>
+      <p class="uncertain" style="margin-top:0.4rem;">
+        Note: these figures assume the session did not hit the Pro rate limit. If rate-limiting
+        caused restarts or retries, actual token consumption may have been higher. No direct
+        measurement available.
+      </p>
+    </div>
+  </section>
+
+  <!-- SECTION 4: NEW ISSUES -->
+  <section>
+    <h2>4 — New Issues Emerging in v0.2.0</h2>
+    <p>
+      Issues that did not exist in v0.1.0 and were not anticipated by the improvement plan.
+    </p>
+
+    <div class="card">
+      <h3>Issue A — Bash Tool Permission Blocking Pattern</h3>
+      <p style="font-size:0.9rem;">
+        Three agents were blocked from running git commit via Bash, requiring manual
+        orchestrator intervention. This was not a problem in v0.1.0 (different session
+        or permission scope). The pattern is: agent completes all file writes successfully,
+        then fails at the commit step, returns a "here are the commands to run manually"
+        response. This is recoverable but costs orchestrator attention and 1–2 additional
+        agent invocations.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Recommendation:</strong> Add a standard "blocked commit fallback" section
+        to all agent definitions: <em>"If git commit is blocked by tool permissions, output
+        the exact commands in a code block and mark the task as incomplete — the orchestrator
+        will run them."</em> This makes the failure mode explicit and handled rather than
+        producing an ambiguous half-done state.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>Issue B — PyInstaller Transitive Dependency Data Files</h3>
+      <p style="font-size:0.9rem;">
+        PyInstaller does not automatically bundle non-Python data files from transitive
+        dependencies (files ending in <code>.lark</code>, <code>.json</code>, etc.).
+        <code>rfc3987_syntax</code> (a dependency of <code>jsonschema</code>) ships a
+        <code>.lark</code> grammar file that is loaded at runtime. The ADR-008 risk register
+        focused on direct dependencies (<code>spdx-tools</code>, <code>cyclonedx-bom</code>)
+        but did not inspect the transitive dependency graph for data assets.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Fix applied:</strong> Added <code>collect_data_files('rfc3987_syntax')</code>
+        and <code>collect_data_files('jsonschema')</code> to the spec file. This is the correct
+        PyInstaller idiom. The fix was straightforward once the error was identified from CI logs.
+      </p>
+    </div>
+
+    <div class="card">
+      <h3>Issue C — GitHub Actions Windows + snok/install-poetry@v1 PATH Issue</h3>
+      <p style="font-size:0.9rem;">
+        <code>snok/install-poetry@v1</code> does not reliably add Poetry to PATH in the
+        PowerShell shell used by Windows GitHub Actions runners. This is a known limitation
+        documented in the action's issues. The fix (<code>pip install poetry</code> +
+        <code>shell: bash</code>) is simple but was not pre-empted in ADR-008.
+      </p>
+      <p style="font-size:0.9rem; margin-bottom:0;">
+        <strong>Recommendation:</strong> Add to the Architect agent definition or to a
+        project-level CI conventions note: <em>"On Windows GitHub Actions runners, use
+        <code>pip install poetry</code> and <code>shell: bash</code> as defaults. Avoid
+        <code>snok/install-poetry@v1</code> on Windows due to PATH propagation issues
+        in PowerShell."</em>
+      </p>
+    </div>
+  </section>
+
+  <!-- SECTION 5: IMPROVEMENT IDEAS -->
+  <section>
+    <h2>5 — Improvement Ideas for Next Work Package</h2>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">1</div>
+        <div class="idea-title">Add a "Blocked Bash Fallback" Section to All Agent Definitions</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        Three agents were blocked from git commit in this session. The pattern is consistent
+        and predictable. Each agent definition should include a terminal section:
+        <em>"If any Bash command is denied by tool permissions: output the exact commands
+        in a fenced code block, state clearly that the task is incomplete pending orchestrator
+        action, and do not mark the task done."</em>
+        This prevents the ambiguous half-done state where an agent returns a success-sounding
+        summary but the commit never happened.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~20–30K tokens (3× follow-up agents eliminated)</span>
+        <span class="impact-tag tag-quality">✅ Quality: improved (no missed commits)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 30 min (add section to 5 agent files)</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">2</div>
+        <div class="idea-title">Add PyInstaller Data File Checklist to Architect Agent</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        For any ADR involving binary distribution, the Architect agent should be required
+        to enumerate non-Python data assets in the dependency tree. The check is simple:
+        <em>"For each runtime dependency, inspect its installed directory for non-.py files.
+        Any <code>.json</code>, <code>.lark</code>, <code>.yaml</code>, <code>.txt</code>
+        or similar files that are loaded at runtime must be explicitly listed in <code>datas</code>
+        using <code>collect_data_files(pkg)</code>."</em>
+        This one check would have prevented the Linux binary failure entirely.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~30–50K tokens (1 release re-run + fix cycle eliminated)</span>
+        <span class="impact-tag tag-quality">✅ Quality: improved (first-pass binary works)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 1 hour (update Architect definition + add to ADR template)</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">3</div>
+        <div class="idea-title">Introduce a Lightweight "Spot Review" for New Modules (not full Phase 4)</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        v0.2.0 had no dedicated code review pass. v0.1.0's full Phase 4 review found 13
+        findings including 3 CRITICAL bugs. The right pattern for a maintenance work package
+        (new features on an existing, reviewed codebase) is a lightweight spot review:
+        the Reviewer reads only the new modules (<code>logging_config.py</code>,
+        <code>report_writer.py</code>) and the modified <code>cli.py</code> against the
+        relevant ADRs. This costs ~15–25K tokens vs. ~150K for a full review, and would
+        have caught the frozen-binary issue if included.
+      </p>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        The Planner should explicitly decide per-work-package: full review (new core logic),
+        spot review (new features on existing base), or skip (docs/config only).
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Token cost: +15–25K tokens (new cost, but prevents larger rework)</span>
+        <span class="impact-tag tag-quality">✅ Quality: improved (catches issues before release)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 1 hour (add spot review task to Planner template)</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">4</div>
+        <div class="idea-title">Add Planner Output Length Constraint</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        The Planner consumed ~32K tokens producing a very detailed plan document with
+        extensive prose per task. The orchestrator primarily needs: task table (ID, agent,
+        deps, deliverables), dependency graph, risk register (top 5). Add to the Planner
+        definition: <em>"Output the plan as: (1) summary table — max 20 rows, (2) dependency
+        graph — ASCII or list format, (3) top 5 risks — 2 sentences each. Total output
+        should not exceed 800 words of prose."</em>
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~15–20K tokens per planning invocation</span>
+        <span class="impact-tag tag-quality">→ Quality: neutral (same decisions, less prose)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 20 min (edit Planner definition)</span>
+      </div>
+    </div>
+
+    <div class="idea-card">
+      <div class="idea-header">
+        <div class="idea-num">5</div>
+        <div class="idea-title">Revisit 100% Coverage Target — Return to 97% with Named Exceptions</div>
+      </div>
+      <p style="font-size:0.92rem; margin-bottom:0.5rem;">
+        The quality gate agent consumed ~78K tokens — the highest single-agent spend in the
+        session — largely due to the 100% coverage target requiring tests for frozen-binary
+        paths, <code>PackageNotFoundError</code> fallbacks, and deep exception branches. These
+        are legitimate test cases but cost disproportionately. A policy of 97% minimum with
+        explicit <code># pragma: no cover</code> annotations for genuinely untestable paths
+        (e.g., the <code>sys._MEIPASS</code> frozen binary branch) would reduce the quality
+        gate cost by an estimated 20–30% while maintaining meaningful coverage.
+      </p>
+      <div class="impact-row">
+        <span class="impact-tag tag-token">💰 Est. saving: ~15–25K tokens at quality gate</span>
+        <span class="impact-tag tag-quality">→ Quality: acceptable (named exceptions are documented)</span>
+        <span class="impact-tag tag-effort">🔧 Effort: 30 min (policy decision + add 3–4 pragma annotations)</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="report-footer">
+    <p>Generated by Claude Sonnet 4.6 on 2026-04-09. Token estimates are derived from session metadata and known Claude output rates — treat as indicative, not precise. All improvement effort estimates assume a single experienced practitioner.</p>
+  </div>
+
+</div>
+</body>
+</html>

--- a/poetry.lock
+++ b/poetry.lock
@@ -352,6 +352,22 @@ files = [
 ]
 
 [[package]]
+name = "elementpath"
+version = "5.1.1"
+description = "XPath 1.0/2.0/3.0/3.1 parsers and selectors for ElementTree and lxml"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "elementpath-5.1.1-py3-none-any.whl", hash = "sha256:57637359065e60654422d8474c1749b09bb21348012b7197f868027e3c09c9b9"},
+    {file = "elementpath-5.1.1.tar.gz", hash = "sha256:c4d1bd6aed987258354d0ea004d965eb0a6818213326bd4fd9bde5dacdb20277"},
+]
+
+[package.extras]
+dev = ["coverage", "flake8", "lxml", "lxml-stubs", "memray ; platform_python_implementation != \"PyPy\"", "mypy", "psutil", "sphinx", "tox (>=4.0)", "xmlschema (>=4.0.1)"]
+docs = ["readthedocs-sphinx-search", "sphinx"]
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 description = "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers"
@@ -1689,6 +1705,26 @@ files = [
 ]
 
 [[package]]
+name = "xmlschema"
+version = "4.3.1"
+description = "An XML Schema validator and decoder"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "xmlschema-4.3.1-py3-none-any.whl", hash = "sha256:9560314d70ae87be0aecb8712cfebed636f867707ccf9758d4b0645d607f64b9"},
+    {file = "xmlschema-4.3.1.tar.gz", hash = "sha256:853effdfaf127849d4724368c17bd669e7f1486e15a0376404ad7954ec31a338"},
+]
+
+[package.dependencies]
+elementpath = ">=5.1.0,<6.0.0"
+
+[package.extras]
+codegen = ["jinja2"]
+dev = ["coverage", "flake8", "lxml", "lxml-stubs", "mypy", "psutil", "tox", "xmlschema[docs]"]
+docs = ["jinja2", "sphinx", "sphinx_rtd_theme"]
+
+[[package]]
 name = "xmltodict"
 version = "1.0.4"
 description = "Makes working with XML feel like you are working with JSON"
@@ -1706,4 +1742,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "2041a85e15f95f0ffe4aeefcf36dd525c3a50e09c7a1e82f20649fc88ed0d9b3"
+content-hash = "2c661d9fa2a46a8bc620b564dab9151488f41636dfb656c7540df94c3a27dc7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ click = ">=8.1"
 jsonschema = ">=4.21"
 spdx-tools = ">=0.8"
 cyclonedx-bom = ">=4.0"
+xmlschema = ">=3.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sbom-validator"
-version = "0.1.0"
+version = "0.2.0"
 description = "CLI tool to validate SBOM files against schema and NTIA minimum elements"
 authors = []
 license = "Apache-2.0"

--- a/sandbox/user-demo/mock-webapp-broken.cdx.xml
+++ b/sandbox/user-demo/mock-webapp-broken.cdx.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:99999999-8888-7777-6666-555555555555" version="1">
+  <metadata>
+    <timestamp>2026-04-09T20:30:00Z</timestamp>
+    <authors>
+      <author>
+        <name>Demo Security Team</name>
+      </author>
+    </authors>
+    <component type="application" bom-ref="app-demo-web-1.0.0">
+      <supplier>
+        <name>DemoCorp</name>
+      </supplier>
+      <name>demo-webapp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component bom-ref="pkg:npm/react@18.2.0">
+      <supplier>
+        <name>Meta</name>
+      </supplier>
+      <version>18.2.0</version>
+      <purl>pkg:npm/react@18.2.0</purl>
+    </component>
+  </components>
+</bom>

--- a/sandbox/user-demo/mock-webapp.cdx.json
+++ b/sandbox/user-demo/mock-webapp.cdx.json
@@ -1,0 +1,77 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "serialNumber": "urn:uuid:11111111-2222-3333-4444-555555555555",
+  "metadata": {
+    "timestamp": "2026-04-09T20:30:00Z",
+    "authors": [
+      {
+        "name": "Demo Security Team"
+      }
+    ],
+    "component": {
+      "type": "application",
+      "bom-ref": "app-demo-web-1.0.0",
+      "name": "demo-webapp",
+      "version": "1.0.0",
+      "supplier": {
+        "name": "DemoCorp"
+      }
+    }
+  },
+  "components": [
+    {
+      "type": "framework",
+      "bom-ref": "pkg:npm/react@18.2.0",
+      "name": "react",
+      "version": "18.2.0",
+      "supplier": {
+        "name": "Meta"
+      },
+      "purl": "pkg:npm/react@18.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/axios@1.7.2",
+      "name": "axios",
+      "version": "1.7.2",
+      "supplier": {
+        "name": "OpenJS Foundation"
+      },
+      "purl": "pkg:npm/axios@1.7.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "name": "lodash",
+      "version": "4.17.21",
+      "supplier": {
+        "name": "OpenJS Foundation"
+      },
+      "purl": "pkg:npm/lodash@4.17.21"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "app-demo-web-1.0.0",
+      "dependsOn": [
+        "pkg:npm/react@18.2.0",
+        "pkg:npm/axios@1.7.2",
+        "pkg:npm/lodash@4.17.21"
+      ]
+    },
+    {
+      "ref": "pkg:npm/react@18.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/axios@1.7.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/lodash@4.17.21",
+      "dependsOn": []
+    }
+  ]
+}

--- a/sandbox/user-demo/mock-webapp.cdx.xml
+++ b/sandbox/user-demo/mock-webapp.cdx.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:11111111-2222-3333-4444-555555555555" version="1">
+  <metadata>
+    <timestamp>2026-04-09T20:30:00Z</timestamp>
+    <authors>
+      <author>
+        <name>Demo Security Team</name>
+      </author>
+    </authors>
+    <component type="application" bom-ref="app-demo-web-1.0.0">
+      <supplier>
+        <name>DemoCorp</name>
+      </supplier>
+      <name>demo-webapp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="framework" bom-ref="pkg:npm/react@18.2.0">
+      <supplier>
+        <name>Meta</name>
+      </supplier>
+      <name>react</name>
+      <version>18.2.0</version>
+      <purl>pkg:npm/react@18.2.0</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/axios@1.7.2">
+      <supplier>
+        <name>OpenJS Foundation</name>
+      </supplier>
+      <name>axios</name>
+      <version>1.7.2</version>
+      <purl>pkg:npm/axios@1.7.2</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/lodash@4.17.21">
+      <supplier>
+        <name>OpenJS Foundation</name>
+      </supplier>
+      <name>lodash</name>
+      <version>4.17.21</version>
+      <purl>pkg:npm/lodash@4.17.21</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="app-demo-web-1.0.0">
+      <dependency ref="pkg:npm/react@18.2.0" />
+      <dependency ref="pkg:npm/axios@1.7.2" />
+      <dependency ref="pkg:npm/lodash@4.17.21" />
+    </dependency>
+    <dependency ref="pkg:npm/react@18.2.0" />
+    <dependency ref="pkg:npm/axios@1.7.2" />
+    <dependency ref="pkg:npm/lodash@4.17.21" />
+  </dependencies>
+</bom>

--- a/sandbox/user-demo/spdx-invalid-conformance.spdx.json
+++ b/sandbox/user-demo/spdx-invalid-conformance.spdx.json
@@ -1,0 +1,57 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "acmecorp-myapp-1.0.0",
+  "documentNamespace": "https://example.com/sbom/acmecorp-myapp-1.0.0-no-supplier",
+  "creationInfo": {
+    "created": "2024-01-15T10:00:00Z",
+    "creators": [
+      "Tool: sbom-generator-1.0",
+      "Organization: AcmeCorp"
+    ]
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-requests",
+      "name": "requests",
+      "versionInfo": "2.31.0",
+      "downloadLocation": "https://pypi.org/project/requests/2.31.0/",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/requests@2.31.0"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Package-urllib3",
+      "name": "urllib3",
+      "versionInfo": "2.1.0",
+      "supplier": "Organization: AcmeCorp",
+      "downloadLocation": "https://pypi.org/project/urllib3/2.1.0/",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/urllib3@2.1.0"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-requests"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-requests",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-urllib3"
+    }
+  ]
+}

--- a/sandbox/user-demo/spdx-invalid-schema.spdx.json
+++ b/sandbox/user-demo/spdx-invalid-schema.spdx.json
@@ -1,0 +1,37 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "acmecorp-myapp-1.0.0",
+  "documentNamespace": "https://example.com/sbom/acmecorp-myapp-1.0.0-invalid",
+  "creationInfo": {
+    "created": "2024-01-15T10:00:00Z",
+    "creators": [
+      "Tool: sbom-generator-1.0",
+      "Organization: AcmeCorp"
+    ]
+  },
+  "packages": [
+    {
+      "name": "requests",
+      "versionInfo": "2.31.0",
+      "supplier": "Organization: AcmeCorp",
+      "downloadLocation": "https://pypi.org/project/requests/2.31.0/",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/requests@2.31.0"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-requests"
+    }
+  ]
+}

--- a/sandbox/user-demo/spdx-valid.spdx.json
+++ b/sandbox/user-demo/spdx-valid.spdx.json
@@ -1,0 +1,43 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "acmecorp-myapp-1.0.0",
+  "documentNamespace": "https://example.com/sbom/acmecorp-myapp-1.0.0-a1b2c3d4",
+  "creationInfo": {
+    "created": "2024-01-15T10:00:00Z",
+    "creators": [
+      "Tool: sbom-generator-1.0",
+      "Organization: AcmeCorp"
+    ]
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-requests",
+      "name": "requests",
+      "versionInfo": "2.31.0",
+      "supplier": "Organization: AcmeCorp",
+      "downloadLocation": "https://pypi.org/project/requests/2.31.0/",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/requests@2.31.0"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-requests"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Package-requests"
+    }
+  ]
+}

--- a/sbom_validator.spec
+++ b/sbom_validator.spec
@@ -20,6 +20,8 @@ a = Analysis(
     datas=[
         (str(schemas_dir / "spdx-2.3.schema.json"), "schemas"),
         (str(schemas_dir / "cyclonedx-1.6.schema.json"), "schemas"),
+        (str(schemas_dir / "cyclonedx-1.6.schema.xsd"), "schemas"),
+        (str(schemas_dir / "cyclonedx-spdx.xsd"), "schemas"),
     ] + _extra_datas,
     hiddenimports=[
         "jsonschema.validators",

--- a/src/sbom_validator/__init__.py
+++ b/src/sbom_validator/__init__.py
@@ -1,3 +1,3 @@
 """SBOM Validator — validates SPDX 2.3 and CycloneDX 1.6 JSON files."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/sbom_validator/cli.py
+++ b/src/sbom_validator/cli.py
@@ -12,6 +12,7 @@ import click
 from sbom_validator import __version__
 from sbom_validator.logging_config import configure_logging
 from sbom_validator.models import ValidationResult, ValidationStatus
+from sbom_validator.presentation import humanize_field_path, humanize_message
 from sbom_validator.report_writer import write_reports
 from sbom_validator.validator import validate
 
@@ -44,7 +45,11 @@ def _exit_code(result: ValidationResult) -> int:
 
 
 def _render_text(result: ValidationResult) -> str:
-    """Render a human-readable text report."""
+    """Render a human-readable text report.
+
+    Rule IDs are intentionally omitted from text output to reduce
+    implementation-detail noise for end users.
+    """
     lines: list[str] = []
     status_label = result.status.value  # "PASS", "FAIL", "ERROR"
     lines.append(f"Status:  {status_label}")
@@ -55,7 +60,8 @@ def _render_text(result: ValidationResult) -> str:
         lines.append(f"Issues:  {len(result.issues)}")
         for issue in result.issues:
             lines.append(
-                f"  [{issue.severity.value}] {issue.field_path}: {issue.message} ({issue.rule})"
+                f"  [{issue.severity.value}] {humanize_field_path(issue.field_path)}: "
+                f"{humanize_message(issue.message)}"
             )
     else:
         if result.status == ValidationStatus.PASS:

--- a/src/sbom_validator/format_detector.py
+++ b/src/sbom_validator/format_detector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from sbom_validator.exceptions import ParseError, UnsupportedFormatError
@@ -11,11 +12,30 @@ from sbom_validator.exceptions import ParseError, UnsupportedFormatError
 logger = logging.getLogger(__name__)
 
 
+def _is_cyclonedx_xml(content: str) -> bool:
+    """Return True when content is CycloneDX 1.6 XML."""
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError:
+        return False
+
+    namespace = ""
+    if root.tag.startswith("{") and "}" in root.tag:
+        namespace = root.tag[1 : root.tag.index("}")]
+    local_name = root.tag.split("}", 1)[-1]
+
+    if local_name != "bom":
+        return False
+    if namespace != "http://cyclonedx.org/schema/bom/1.6":
+        return False
+    return root.attrib.get("version") == "1"
+
+
 def detect_format(file_path: Path) -> str:
     """Return 'spdx' or 'cyclonedx' based on file content.
 
     Raises:
-        ParseError: If the file cannot be read or is not valid JSON.
+        ParseError: If the file cannot be read.
         UnsupportedFormatError: If the format cannot be determined.
     """
     if not file_path.exists():
@@ -28,9 +48,13 @@ def detect_format(file_path: Path) -> str:
 
     try:
         data = json.loads(content)
-    except json.JSONDecodeError as exc:
-        logger.warning("Failed to parse JSON from %s: %s", file_path, exc)
-        raise ParseError(f"Invalid JSON in file: {file_path}") from exc
+    except json.JSONDecodeError:
+        if _is_cyclonedx_xml(content):
+            logger.info("Format detected: cyclonedx XML (file: %s)", file_path)
+            return "cyclonedx"
+        msg = f"Cannot determine SBOM format from {file_path}: invalid JSON and not CycloneDX 1.6 XML."
+        logger.warning("Unsupported format in %s: %s", file_path, msg)
+        raise UnsupportedFormatError(msg)
 
     if not isinstance(data, dict):
         msg = f"Expected a JSON object at the root of {file_path}, got {type(data).__name__}"

--- a/src/sbom_validator/ntia_checker.py
+++ b/src/sbom_validator/ntia_checker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 
 from sbom_validator.models import IssueSeverity, NormalizedSBOM, ValidationIssue
 
@@ -126,13 +127,31 @@ def _check_author(sbom: NormalizedSBOM) -> list[ValidationIssue]:
 
 
 def _check_timestamp(sbom: NormalizedSBOM) -> list[ValidationIssue]:
-    """FR-10: The SBOM must contain a non-empty timestamp."""
+    """FR-10: The SBOM must contain a valid ISO 8601 timestamp."""
     if sbom.timestamp is None or sbom.timestamp.strip() == "":
         return [
             ValidationIssue(
                 severity=IssueSeverity.ERROR,
                 field_path="timestamp",
                 message=("SBOM is missing a creation timestamp (NTIA FR-10)"),
+                rule="FR-10",
+            )
+        ]
+
+    raw_timestamp = sbom.timestamp.strip()
+    # Accept "Z" suffix by normalizing to a UTC offset for fromisoformat().
+    normalized = raw_timestamp[:-1] + "+00:00" if raw_timestamp.endswith("Z") else raw_timestamp
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError:
+        return [
+            ValidationIssue(
+                severity=IssueSeverity.ERROR,
+                field_path="timestamp",
+                message=(
+                    f"SBOM timestamp '{raw_timestamp}' is not a valid ISO 8601 date-time "
+                    "(NTIA FR-10)"
+                ),
                 rule="FR-10",
             )
         ]

--- a/src/sbom_validator/parsers/cyclonedx_parser.py
+++ b/src/sbom_validator/parsers/cyclonedx_parser.py
@@ -1,8 +1,9 @@
-"""Parser for CycloneDX 1.6 JSON SBOM files."""
+"""Parser for CycloneDX 1.6 JSON and XML SBOM files."""
 
 from __future__ import annotations
 
 import json
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -82,8 +83,107 @@ def _parse_relationships(
     return tuple(relationships)
 
 
+def _extract_author_from_xml(metadata: ET.Element, namespace: str) -> str | None:
+    """Extract author from CycloneDX XML metadata."""
+    author_names = [
+        (node.text or "").strip()
+        for node in metadata.findall(
+            f"./{{{namespace}}}authors/{{{namespace}}}author/{{{namespace}}}name"
+        )
+        if (node.text or "").strip()
+    ]
+    if author_names:
+        return ", ".join(author_names)
+    manufacture_name = metadata.findtext(
+        f"./{{{namespace}}}manufacture/{{{namespace}}}name",
+        default=None,
+    )
+    if manufacture_name:
+        manufacture_name = manufacture_name.strip()
+    return manufacture_name or None
+
+
+def _parse_cyclonedx_xml(document: str) -> NormalizedSBOM:
+    """Parse CycloneDX XML content into NormalizedSBOM."""
+    try:
+        root = ET.fromstring(document)
+    except ET.ParseError as exc:
+        raise ParseError(f"Invalid XML document: {exc}") from exc
+
+    namespace = ""
+    if root.tag.startswith("{") and "}" in root.tag:
+        namespace = root.tag[1 : root.tag.index("}")]
+
+    metadata = root.find(f"./{{{namespace}}}metadata")
+    author = _extract_author_from_xml(metadata, namespace) if metadata is not None else None
+    timestamp = (
+        metadata.findtext(f"./{{{namespace}}}timestamp", default=None)
+        if metadata is not None
+        else None
+    )
+    if timestamp:
+        timestamp = timestamp.strip()
+
+    components: list[NormalizedComponent] = []
+    for component in root.findall(f"./{{{namespace}}}components/{{{namespace}}}component"):
+        name = (component.findtext(f"./{{{namespace}}}name", default="") or "").strip()
+        version = component.findtext(f"./{{{namespace}}}version", default=None)
+        if version is not None:
+            version = version.strip() or None
+        component_id = (
+            component.attrib.get("bom-ref")
+            or f"{name}@{version if version is not None else 'unknown'}"
+        )
+        supplier = component.findtext(
+            f"./{{{namespace}}}supplier/{{{namespace}}}name", default=None
+        )
+        if supplier is not None:
+            supplier = supplier.strip() or None
+        identifiers: list[str] = []
+        purl = component.findtext(f"./{{{namespace}}}purl", default=None)
+        cpe = component.findtext(f"./{{{namespace}}}cpe", default=None)
+        if purl and purl.strip():
+            identifiers.append(purl.strip())
+        if cpe and cpe.strip():
+            identifiers.append(cpe.strip())
+        components.append(
+            NormalizedComponent(
+                component_id=component_id,
+                name=name,
+                version=version,
+                supplier=supplier,
+                identifiers=tuple(identifiers),
+            )
+        )
+
+    relationships: list[NormalizedRelationship] = []
+    for dependency in root.findall(f"./{{{namespace}}}dependencies/{{{namespace}}}dependency"):
+        ref = dependency.attrib.get("ref", "")
+        if not ref:
+            continue
+        for dep_ref in dependency.findall(f"./{{{namespace}}}dependency"):
+            to_id = dep_ref.attrib.get("ref", "")
+            if not to_id:
+                continue
+            relationships.append(
+                NormalizedRelationship(
+                    from_id=ref,
+                    to_id=to_id,
+                    relationship_type="DEPENDS_ON",
+                )
+            )
+
+    return NormalizedSBOM(
+        format="cyclonedx",
+        author=author,
+        timestamp=timestamp,
+        components=tuple(components),
+        relationships=tuple(relationships),
+    )
+
+
 def parse_cyclonedx(file_path: Path) -> NormalizedSBOM:
-    """Parse a CycloneDX 1.6 JSON file into a NormalizedSBOM.
+    """Parse a CycloneDX 1.6 JSON or XML file into a NormalizedSBOM.
 
     Raises:
         ParseError: If the file cannot be read or parsed.
@@ -98,8 +198,8 @@ def parse_cyclonedx(file_path: Path) -> NormalizedSBOM:
 
     try:
         document: dict[str, Any] = json.loads(raw_text)
-    except json.JSONDecodeError as e:
-        raise ParseError(f"Invalid JSON in '{file_path}': {e}") from e
+    except json.JSONDecodeError:
+        return _parse_cyclonedx_xml(raw_text)
 
     metadata: dict[str, Any] = document.get("metadata", {})
 

--- a/src/sbom_validator/presentation.py
+++ b/src/sbom_validator/presentation.py
@@ -32,10 +32,7 @@ def humanize_message(message: str) -> str:
     required_property = _REQUIRED_PROPERTY_RE.match(clean)
     if required_property:
         prop = required_property.group(1)
-        return (
-            f"Missing required field '{prop}'. "
-            f"Hint: add '{prop}' at this location."
-        )
+        return f"Missing required field '{prop}'. " f"Hint: add '{prop}' at this location."
 
     if "missing required attribute 'type'" in clean:
         return (

--- a/src/sbom_validator/presentation.py
+++ b/src/sbom_validator/presentation.py
@@ -1,0 +1,68 @@
+"""Helpers for human-friendly validation output rendering."""
+
+from __future__ import annotations
+
+import re
+
+_XML_NAMESPACE_RE = re.compile(r"\{[^}]+\}")
+_XML_TAG_PREFIX_RE = re.compile(r"Tag '([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)'")
+_NTIA_RULE_SUFFIX_RE = re.compile(r"\s*\(NTIA\s+FR-\d+\)\s*$")
+_REQUIRED_PROPERTY_RE = re.compile(r"^'([^']+)' is a required property$")
+
+
+def humanize_field_path(field_path: str) -> str:
+    """Return a user-friendly field path for CLI/HTML display."""
+    if not field_path:
+        return field_path
+    # XML validators often emit expanded namespaces; hide them in user-facing output.
+    return _XML_NAMESPACE_RE.sub("", field_path)
+
+
+def humanize_message(message: str) -> str:
+    """Return a user-friendly issue message for CLI/HTML display."""
+    if not message:
+        return message
+    # Remove expanded XML namespaces from tags in messages.
+    clean = _XML_NAMESPACE_RE.sub("", message)
+    # Convert compact prefix-style references (e.g. bom:name) to plain element names.
+    clean = _XML_TAG_PREFIX_RE.sub(lambda m: f"Element '{m.group(2)}'", clean)
+    # Hide internal NTIA rule IDs from end-user text.
+    clean = _NTIA_RULE_SUFFIX_RE.sub("", clean)
+
+    required_property = _REQUIRED_PROPERTY_RE.match(clean)
+    if required_property:
+        prop = required_property.group(1)
+        return (
+            f"Missing required field '{prop}'. "
+            f"Hint: add '{prop}' at this location."
+        )
+
+    if "missing required attribute 'type'" in clean:
+        return (
+            "Missing required attribute 'type'. "
+            "Hint: set component type (for example 'library', 'application', or 'framework')."
+        )
+
+    if "missing a supplier name" in clean:
+        return (
+            f"{clean}. Hint: provide a supplier/organization name for this component."
+            if not clean.endswith(".")
+            else f"{clean} Hint: provide a supplier/organization name for this component."
+        )
+
+    if "Element 'name' expected." in clean and "Unexpected child with tag" in clean:
+        return (
+            f"{clean} Hint: ensure the component includes <name> before <version>."
+            if not clean.endswith(".")
+            else f"{clean} Hint: ensure the component includes <name> before <version>."
+        )
+
+    return clean
+
+
+def split_message_and_hint(message: str) -> tuple[str, str | None]:
+    """Split a humanized message into primary message and optional hint."""
+    base, sep, hint = message.partition(" Hint: ")
+    if not sep:
+        return message, None
+    return base.strip(), hint.strip() or None

--- a/src/sbom_validator/report_writer.py
+++ b/src/sbom_validator/report_writer.py
@@ -14,7 +14,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from sbom_validator.models import IssueSeverity, ValidationResult
-from sbom_validator.presentation import humanize_field_path, humanize_message, split_message_and_hint
+from sbom_validator.presentation import (
+    humanize_field_path,
+    humanize_message,
+    split_message_and_hint,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/sbom_validator/report_writer.py
+++ b/src/sbom_validator/report_writer.py
@@ -10,7 +10,7 @@ import importlib.metadata
 import json
 import logging
 import string
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sbom_validator.models import IssueSeverity, ValidationResult
@@ -163,11 +163,11 @@ def _escape(text: str) -> str:
 
 
 def _tool_version() -> str:
-    """Return the installed package version, falling back to '0.2.0'."""
+    """Return the installed package version, falling back to 'unknown'."""
     try:
         return importlib.metadata.version("sbom-validator")
     except importlib.metadata.PackageNotFoundError:
-        return "0.2.0"
+        return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -195,8 +195,9 @@ def write_reports(
                  be written (e.g., permission denied).
     """
     # Compute shared timestamp and stems once.
-    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
-    generated_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_utc = datetime.now(UTC)
+    timestamp = now_utc.strftime("%Y%m%d-%H%M%S")
+    generated_at = now_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
     stem = Path(result.file_path).stem
     version = _tool_version()
 
@@ -220,32 +221,6 @@ def write_reports(
     error_count = sum(1 for i in result.issues if i.severity == IssueSeverity.ERROR)
     warning_count = sum(1 for i in result.issues if i.severity == IssueSeverity.WARNING)
     info_count = sum(1 for i in result.issues if i.severity == IssueSeverity.INFO)
-
-    # -----------------------------------------------------------------------
-    # Build JSON report
-    # -----------------------------------------------------------------------
-    json_data: dict[object, object] = {
-        "generated_at": generated_at,
-        "tool_version": version,
-        "file_path": result.file_path,
-        "format_detected": format_detected_expanded,
-        "status": str(result.status),
-        "summary": {
-            "error_count": error_count,
-            "warning_count": warning_count,
-            "info_count": info_count,
-        },
-        "issues": [
-            {
-                "severity": str(issue.severity),
-                "rule": issue.rule,
-                "field_path": issue.field_path,
-                "message": issue.message,
-            }
-            for issue in sorted_issues
-        ],
-    }
-    json_path.write_text(json.dumps(json_data, indent=2), encoding="utf-8")
 
     # -----------------------------------------------------------------------
     # Build HTML report
@@ -289,6 +264,32 @@ def write_reports(
         issues_section=issues_section,
     )
     html_path.write_text(html_content, encoding="utf-8")
+
+    # -----------------------------------------------------------------------
+    # Build JSON report
+    # -----------------------------------------------------------------------
+    json_data: dict[object, object] = {
+        "generated_at": generated_at,
+        "tool_version": version,
+        "file_path": result.file_path,
+        "format_detected": format_detected_expanded,
+        "status": str(result.status),
+        "summary": {
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "info_count": info_count,
+        },
+        "issues": [
+            {
+                "severity": str(issue.severity),
+                "rule": issue.rule,
+                "field_path": issue.field_path,
+                "message": issue.message,
+            }
+            for issue in sorted_issues
+        ],
+    }
+    json_path.write_text(json.dumps(json_data, indent=2), encoding="utf-8")
 
     logger.info("Reports written: HTML=%s  JSON=%s", html_path, json_path)
 

--- a/src/sbom_validator/report_writer.py
+++ b/src/sbom_validator/report_writer.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from sbom_validator.models import IssueSeverity, ValidationResult
+from sbom_validator.presentation import humanize_field_path, humanize_message, split_message_and_hint
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +188,10 @@ def write_reports(
         result: The completed ValidationResult from the validator pipeline.
         report_dir: Directory in which to write the two report files.
 
+    Human-facing HTML intentionally omits internal rule IDs to keep output
+    focused on actionable issue context. JSON reports still include rule IDs
+    for programmatic consumers.
+
     Returns:
         A two-tuple (html_path, json_path) of the paths actually written.
 
@@ -229,19 +234,23 @@ def write_reports(
     format_display = format_detected_expanded if format_detected_expanded is not None else "Unknown"
 
     if sorted_issues:
-        rows = "\n".join(
-            f"    <tr>"
-            f'<td class="sev-{_escape(str(issue.severity))}">{_escape(str(issue.severity))}</td>'
-            f"<td>{_escape(issue.rule)}</td>"
-            f"<td>{_escape(issue.field_path)}</td>"
-            f"<td>{_escape(issue.message)}</td>"
-            f"</tr>"
-            for issue in sorted_issues
-        )
+        rows_parts: list[str] = []
+        for issue in sorted_issues:
+            friendly_message = humanize_message(issue.message)
+            base_message, hint = split_message_and_hint(friendly_message)
+            rows_parts.append(
+                f"    <tr>"
+                f'<td class="sev-{_escape(str(issue.severity))}">{_escape(str(issue.severity))}</td>'
+                f"<td>{_escape(humanize_field_path(issue.field_path))}</td>"
+                f"<td>{_escape(base_message)}</td>"
+                f"<td>{_escape(hint or '-')}</td>"
+                f"</tr>"
+            )
+        rows = "\n".join(rows_parts)
         issues_section = (
             "<table>\n"
             "  <thead>\n"
-            "    <tr><th>Severity</th><th>Rule</th><th>Field Path</th><th>Message</th></tr>\n"
+            "    <tr><th>Severity</th><th>Field Path</th><th>Message</th><th>Hint</th></tr>\n"
             "  </thead>\n"
             "  <tbody>\n"
             f"{rows}\n"

--- a/src/sbom_validator/schema_validator.py
+++ b/src/sbom_validator/schema_validator.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
 import jsonschema
 import jsonschema.exceptions
+import xmlschema
 
 from sbom_validator.models import IssueSeverity, ValidationIssue
 
@@ -38,6 +40,7 @@ _FORMAT_RULES: dict[str, str] = {
 }
 
 _loaded_schemas: dict[str, dict[str, Any]] = {}
+_loaded_xml_schemas: dict[str, xmlschema.XMLSchemaBase] = {}
 
 
 def _load_schema(format_name: str) -> dict[str, Any]:
@@ -48,11 +51,69 @@ def _load_schema(format_name: str) -> dict[str, Any]:
     return _loaded_schemas[format_name]
 
 
-def validate_schema(raw_doc: dict[str, Any], format_name: str) -> list[ValidationIssue]:
-    """Validate raw JSON document against the appropriate schema.
+def _load_cyclonedx_xml_schema() -> xmlschema.XMLSchemaBase:
+    """Load and cache the bundled CycloneDX 1.6 XML schema."""
+    key = "cyclonedx-xml"
+    if key not in _loaded_xml_schemas:
+        schema_path = _schemas_dir() / "cyclonedx-1.6.schema.xsd"
+        _loaded_xml_schemas[key] = xmlschema.XMLSchema(str(schema_path))
+    return _loaded_xml_schemas[key]
+
+
+def _validate_json_schema(
+    raw_doc: dict[str, Any], format_name: str, rule: str
+) -> list[ValidationIssue]:
+    """Validate a JSON document and return ValidationIssue items."""
+    schema = _load_schema(format_name)
+    validator = jsonschema.Draft7Validator(schema)
+    issues: list[ValidationIssue] = []
+    for error in validator.iter_errors(raw_doc):
+        field_path = ".".join(str(p) for p in error.absolute_path) if error.absolute_path else "$"
+        issues.append(
+            ValidationIssue(
+                severity=IssueSeverity.ERROR,
+                field_path=field_path,
+                message=error.message,
+                rule=rule,
+            )
+        )
+    return issues
+
+
+def _validate_cyclonedx_xml(raw_doc: str, rule: str) -> list[ValidationIssue]:
+    """Validate a CycloneDX XML document against the bundled XSD."""
+    issues: list[ValidationIssue] = []
+    try:
+        root = ET.fromstring(raw_doc)
+    except ET.ParseError as exc:
+        return [
+            ValidationIssue(
+                severity=IssueSeverity.ERROR,
+                field_path="$",
+                message=f"Invalid XML: {exc}",
+                rule=rule,
+            )
+        ]
+
+    validator = _load_cyclonedx_xml_schema()
+    for error in validator.iter_errors(root):
+        field_path = error.path or "$"
+        issues.append(
+            ValidationIssue(
+                severity=IssueSeverity.ERROR,
+                field_path=field_path,
+                message=error.reason or str(error),
+                rule=rule,
+            )
+        )
+    return issues
+
+
+def validate_schema(raw_doc: dict[str, Any] | str, format_name: str) -> list[ValidationIssue]:
+    """Validate raw document against the appropriate schema.
 
     Args:
-        raw_doc: Parsed JSON document as a dict.
+        raw_doc: Parsed JSON document as a dict, or XML string for CycloneDX XML.
         format_name: Either 'spdx' or 'cyclonedx'.
 
     Returns:
@@ -65,25 +126,15 @@ def validate_schema(raw_doc: dict[str, Any], format_name: str) -> list[Validatio
         raise ValueError(f"Unknown format: {format_name!r}. Expected one of: {list(_SCHEMA_FILES)}")
 
     logger.debug("Running schema validation for format %s", format_name)
-    schema = _load_schema(format_name)
     rule = _FORMAT_RULES[format_name]
-
-    validator = jsonschema.Draft7Validator(schema)
-
-    issues: list[ValidationIssue] = []
-    for error in validator.iter_errors(raw_doc):
-        if error.absolute_path:
-            field_path = ".".join(str(p) for p in error.absolute_path)
-        else:
-            field_path = "$"
-        issues.append(
-            ValidationIssue(
-                severity=IssueSeverity.ERROR,
-                field_path=field_path,
-                message=error.message,
-                rule=rule,
-            )
-        )
+    if format_name == "spdx":
+        if not isinstance(raw_doc, dict):
+            raise ValueError("SPDX schema validation expects a JSON object document.")
+        issues = _validate_json_schema(raw_doc, format_name, rule)
+    elif isinstance(raw_doc, str):
+        issues = _validate_cyclonedx_xml(raw_doc, rule)
+    else:
+        issues = _validate_json_schema(raw_doc, format_name, rule)
 
     if issues:
         logger.info("Schema validation found %d error(s)", len(issues))

--- a/src/sbom_validator/schemas/cyclonedx-1.6.schema.xsd
+++ b/src/sbom_validator/schemas/cyclonedx-1.6.schema.xsd
@@ -1,0 +1,8432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CycloneDX Bill of Material (BOM) Specification
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           xmlns:bom="http://cyclonedx.org/schema/bom/1.6"
+           xmlns:spdx="http://cyclonedx.org/schema/spdx"
+           elementFormDefault="qualified"
+           targetNamespace="http://cyclonedx.org/schema/bom/1.6"
+           vc:minVersion="1.0"
+           vc:maxVersion="1.1"
+           version="1.6.1">
+
+    <xs:import namespace="http://cyclonedx.org/schema/spdx" schemaLocation="cyclonedx-spdx.xsd"/>
+
+    <xs:annotation>
+        <xs:documentation>
+            <name>CycloneDX Bill of Materials Standard</name>
+            <url>https://cyclonedx.org/</url>
+            <license uri="http://www.apache.org/licenses/LICENSE-2.0"
+                     version="2.0">Apache License, Version 2.0</license>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:simpleType name="refType">
+        <xs:annotation>
+            <xs:documentation>Identifier for referable and therefore interlink-able elements.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <!-- value SHOULD not start with the BOM-Link intro "urn:cdx:" -->
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="refLinkType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Descriptor for an element identified by the attribute "bom-ref" in the same BOM document.
+                In contrast to `bomLinkElementType`.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="bom:refType"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="versionType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en"><![CDATA[
+                A single disjunctive version identifier, for a component or service.
+
+                Example values:
+                - "9.0.14"
+                - "v1.33.7"
+                - "7.0.0-M1"
+                - "2.0pre1"
+                - "1.0.0-beta1"
+                - "0.8.15"
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:normalizedString">
+            <xs:maxLength value="1024"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="versionRangeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en"><![CDATA[
+                A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec
+
+                Example values:
+                - "vers:cargo/9.0.14"
+                - "vers:npm/1.2.3|>=2.0.0|<5.0.0"
+                - "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1"
+                - "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1"
+                - "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:normalizedString">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="4096"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="bomLinkDocumentType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Descriptor for another BOM document.
+                See https://cyclonedx.org/capabilities/bomlink/
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <!-- part of the pattern is based on `bom.serialNumber`'s pattern -->
+            <xs:pattern value="urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="bomLinkElementType">
+        <xs:annotation>
+            <xs:documentation  xml:lang="en">
+                Descriptor for an element in another BOM document.
+                See https://cyclonedx.org/capabilities/bomlink/
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <!-- part of the pattern is based on `bom.serialNumber`'s pattern -->
+            <xs:pattern value="urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="bomLinkType">
+        <xs:union memberTypes="bom:bomLinkDocumentType bom:bomLinkElementType"/>
+    </xs:simpleType>
+
+    <xs:complexType name="metadata">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the BOM was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="lifecycles" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="lifecycle" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:sequence>
+                                        <xs:element name="phase" type="bom:lifecyclePhaseType" minOccurs="1" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A pre-defined phase in the product lifecycle.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:sequence>
+                                        <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the lifecycle phase
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The description of the lifecycle phase
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool(s) used in the creation of the BOM.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="tool" minOccurs="0" type="bom:toolType">
+                                <xs:annotation>
+                                    <xs:documentation>DEPRECATED. Use tools\components or tools\services instead.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="1">
+                            <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of software and hardware components used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of services used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The person(s) who created the BOM.
+                        Authors are common in BOMs created through manual processes. BOMs created through automated means may have './manufacturer' instead.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="author" type="bom:organizationalContact"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="component" type="bom:component" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The component that the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacturer" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The organization that created the BOM.
+                        Manufacturer is common in BOMs created through automated processes. BOMs created through manual means may have './authors' instead.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacture" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use the `./component/manufacturer` instead.
+                        The organization that manufactured the component that the BOM describes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that supplied the component that the BOM describes. The
+                        supplier may often be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The license information for the BOM document.
+                        This may be different from the license(s) of the component(s) that the BOM describes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="lifecyclePhaseType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="design">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM produced early in the development lifecycle containing inventory of components and services
+                        that are proposed or planned to be used. The inventory may need to be procured, retrieved,
+                        or resourced prior to use.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="pre-build">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information obtained prior to a build process and may contain source files
+                        and development artifacts and manifests. The inventory may need to be resolved and retrieved
+                        prior to use.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information obtained during a build process where component inventory is
+                        available for use. The precise versions of resolved components are usually available at this
+                        time as well as the provenance of where the components were retrieved from.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="post-build">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information obtained after a build process has completed and the resulting
+                        components(s) are available for further analysis. Built components may exist as the result of a
+                        CI/CD process, may have been installed or deployed to a system or device, and may need to be
+                        retrieved or extracted from the system or device.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="operations">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM produced that represents inventory that is running and operational. This may include staging
+                        or production environments and will generally encompass multiple SBOMs describing the applications
+                        and operating system, along with HBOMs describing the hardware that makes up the system. Operations
+                        Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations,
+                        and additional dependencies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="discovery">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM consisting of information observed through network discovery providing point-in-time
+                        enumeration of embedded, on-premise, and cloud-native services such as server applications,
+                        connected devices, microservices, and serverless functions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="decommission">
+                <xs:annotation>
+                    <xs:documentation>
+                        BOM containing inventory that will be, or has been retired from operations.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="organizationalEntity">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the organization</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="address" type="bom:postalAddressType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The physical address (location) of the organization.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        The URL of the organization. Multiple URLs are allowed.
+                        Example: https://example.com
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="contact" type="bom:organizationalContact" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A contact person at the organization. Multiple contacts are allowed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="toolType">
+        <xs:annotation>
+            <xs:documentation>Information about the automated or manual tool used</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="vendor" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The name of the vendor who created the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>The name of the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" maxOccurs="1" type="bom:versionType">
+                <xs:annotation>
+                    <xs:documentation>The version of the tool</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the tool.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="organizationalContact">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the contact</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The email address of the contact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="phone" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The phone number of the contact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the object elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="componentsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="component" type="bom:component"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="component">
+        <xs:sequence>
+            <xs:element name="supplier" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that supplied the component. The supplier may often
+                        be the manufacturer, but may also be a distributor or repackager.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="manufacturer" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The organization that created the component.
+                        Manufacturer is common in components created through automated processes. Components created through manual means may have './authors' instead.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="authors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The person(s) who created the component.
+                        Authors are common in components created through manual processes. Components created through automated means may have `./manufacturer` instead.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="author" type="bom:organizationalContact"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="author" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use `./authors` or `./manufacturer` instead.
+                        The person(s) or organization(s) that authored the component.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="publisher" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person(s) or organization(s) that published the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="group" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The grouping name or identifier. This will often be a shortened, single
+                        name of the company or project that produced the component, or the source package or
+                        domain name. Whitespace and special characters should be avoided. Examples include:
+                        apache, org.apache.commons, and apache.org.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the component. This will often be a shortened, single name
+                        of the component. Examples: commons-lang3 and jquery</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="bom:versionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The component version. The version should ideally comply with semantic versioning
+                        but is not enforced.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies a description for the component</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="scope" type="bom:scope" minOccurs="0" maxOccurs="1" default="required">
+                <xs:annotation>
+                    <xs:documentation>Specifies the scope of the component. If scope is not specified, 'required'
+                        scope SHOULD be assumed by the consumer of the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The hashes of the component.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A copyright notice informing users of the underlying claims to copyright ownership in a published work.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cpe" type="bom:cpe" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See https://nvd.nist.gov/products/cpe
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="purl" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the package-url (purl). The purl, if specified, must be valid and conform
+                        to the specification defined at: https://github.com/package-url/purl-spec
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="omniborId" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform
+                        to the specification defined at: https://www.iana.org/assignments/uri-schemes/prov/gitoid
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="swhid" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must
+                        be valid and conform to the specification defined at:
+                        https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="swid" type="bom:swidType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modified" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        DEPRECATED - DO NOT USE. This will be removed in a future version. Use the pedigree
+                        element instead to supply information on exactly how the component was modified.
+                        A boolean value indicating if the component has been modified from the original.
+                        A value of true indicates the component is a derivative of the original.
+                        A value of false indicates the component has not been modified from the original.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="pedigree" type="bom:pedigreeType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component pedigree is a way to document complex supply chain scenarios where components are
+                        created, distributed, modified, redistributed, combined with other components, etc.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the
+                        component or to the project the component describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="components" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of software and hardware components included in the parent component. This is not a
+                        dependency tree. It provides a way to specify a hierarchical representation of component
+                        assemblies, similar to system -> subsystem -> parts assembly in physical supply chains.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="component" type="bom:component"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidence" type="bom:componentEvidenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document evidence collected through various forms of extraction or analysis.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies optional release notes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modelCard" type="bom:modelCardType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A model card describes the intended uses of a machine learning model and potential
+                        limitations, including biases and ethical considerations. Model cards typically contain the
+                        training parameters, which datasets were used to train the model, performance metrics, and other
+                        relevant data useful for ML transparency. This object SHOULD be specified for any component of
+                        type `machine-learning-model` and must not be specified for other component types.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" type="bom:componentDataType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>This object SHOULD be specified for any component of type `data` and must not be
+                        specified for other component types.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cryptoProperties" type="bom:cryptoPropertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cryptographic assets have properties that uniquely define them and that make them actionable
+                        for further reasoning. As an example, it makes a difference if one knows the algorithm family
+                        (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the
+                        security level and the algorithm primitive (authenticated encryption) is only defined by the
+                        definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1
+                        vs. HMAC-SHA1 also makes a difference.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:classification" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the type of component. For software components, classify as application if no more
+                    specific appropriate classification is available or cannot be determined for the component.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mime-type" type="bom:mimeType">
+            <xs:annotation>
+                <xs:documentation>
+                    The optional mime-type of the component. When used on file components, the mime-type
+                    can provide additional context about the kind of file being represented such as an image,
+                    font, or executable. Some library or framework components may also have an associated mime-type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the component elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="licenseType">
+        <xs:annotation>
+            <xs:documentation>Specifies the details and attributes related to a software license.
+                It can either include a valid SPDX license identifier or a named license, along with additional
+                properties such as license acknowledgment, comprehensive commercial licensing information, and
+                the full text of the license.</xs:documentation>
+            </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="id" type="spdx:licenseId" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the optional full text of the attachment</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to the attachment file. If the attachment is a license or BOM,
+                        an externalReference should also be specified for completeness.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="licensing" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Licensing details describing the licensor/licensee, license type, renewal and
+                        expiration dates, and other important metadata</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="altIds" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>License identifiers that may be used to manage licenses and
+                                    their lifecycle</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="altId" type="xs:normalizedString" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="licensor" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The individual or organization that grants a license to another
+                                    individual or organization</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:choice>
+                                        <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>The organization that granted the license</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>The individual, not associated with an organization,
+                                                    that granted the license</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:choice>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="licensee" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The individual or organization for which a license was granted to</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:choice>
+                                        <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>The organization that was granted the license</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>The individual, not associated with an organization,
+                                                    that was granted the license</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:choice>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="purchaser" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The individual or organization that purchased the license</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:choice>
+                                        <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>The organization that purchased the license</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                        <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                            <xs:annotation>
+                                                <xs:documentation>The individual, not associated with an organization,
+                                                    that purchased the license</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:element>
+                                    </xs:choice>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="purchaseOrder" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The purchase order identifier the purchaser sent to a supplier or
+                                    vendor to authorize a purchase</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="licenseTypes" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The type of license(s) that was granted to the licensee</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="licenseType" type="bom:licenseTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="lastRenewal" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">The timestamp indicating when the license was last
+                                    renewed. For new purchases, this is often the purchase or acquisition date.
+                                    For non-perpetual licenses or subscriptions, this is the timestamp of when the
+                                    license was last renewed.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="expiration" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">The timestamp indicating when the current license
+                                    expires (if applicable).</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the license elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="acknowledgement" type="bom:licenseAcknowledgementEnumerationType">
+            <xs:annotation>
+                <xs:documentation>
+                    Declared licenses and concluded licenses represent two different stages in the
+                    licensing process within software development. Declared licenses refer to the
+                    initial intention of the software authors regarding the licensing terms under
+                    which their code is released. On the other hand, concluded licenses are the
+                    result of a comprehensive analysis of the project's codebase to identify and
+                    confirm the actual licenses of the components used, which may differ from the
+                    initially declared licenses. While declared licenses provide an upfront indication
+                    of the licensing intentions, concluded licenses offer a more thorough understanding
+                    of the actual licensing within a project, facilitating proper compliance and risk
+                    management. Observed licenses are defined in `evidence.licenses`. Observed licenses
+                    form the evidence necessary to substantiate a concluded license.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="attachedTextType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:annotation>
+                    <xs:documentation>The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.</xs:documentation>
+                </xs:annotation>
+                <xs:attribute name="content-type" type="xs:normalizedString" default="text/plain">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Specifies the format and nature of the data being attached, helping systems correctly
+                            interpret and process the content. Common content type examples include `application/json`
+                            for JSON data and `text/plain` for plain text documents.
+                            RFC 2045 section 5.1 outlines the structure and use of content types. For a comprehensive
+                            list of registered content types, refer to the IANA media types registry at
+                            https://www.iana.org/assignments/media-types/media-types.xhtml.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="encoding" type="bom:encoding">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Specifies the optional encoding the text is represented in
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="hashType">
+        <xs:annotation>
+            <xs:documentation>Specifies the file hash of the component</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="bom:hashValue">
+                <xs:attribute name="alg" type="bom:hashAlg" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the algorithm used to create the hash</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="scope">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="required">
+                <xs:annotation>
+                    <xs:documentation>The component is required for runtime</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="optional">
+                <xs:annotation>
+                    <xs:documentation>The component is optional at runtime. Optional components are components that
+                        are not capable of being called due to them not be installed or otherwise accessible by any means.
+                        Components that are installed but due to configuration or other restrictions are prohibited from
+                        being called must be scoped as 'required'.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="excluded">
+                <xs:annotation>
+                    <xs:documentation>Components that are excluded provide the ability to document component usage
+                        for test and other non-runtime purposes. Excluded components are not reachable within a call
+                        graph at runtime.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="classification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="application">
+                <xs:annotation>
+                    <xs:documentation>A software application. Refer to https://en.wikipedia.org/wiki/Application_software
+                        for information about applications.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="framework">
+                <xs:annotation>
+                    <xs:documentation>A software framework. Refer to https://en.wikipedia.org/wiki/Software_framework
+                        for information on how frameworks vary slightly from libraries.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="library">
+                <xs:annotation>
+                    <xs:documentation>A software library. Refer to https://en.wikipedia.org/wiki/Library_(computing)
+                        for information about libraries. All third-party and open source reusable components will likely
+                        be a library. If the library also has key features of a framework, then it should be classified
+                        as a framework. If not, or is unknown, then specifying library is recommended.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="container">
+                <xs:annotation>
+                    <xs:documentation>A packaging and/or runtime format, not specific to any particular technology,
+                        which isolates software inside the container from software outside of a container through
+                        virtualization technology. Refer to https://en.wikipedia.org/wiki/OS-level_virtualization</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="platform">
+                <xs:annotation>
+                    <xs:documentation>A runtime environment which interprets or executes software. This may include
+                        runtimes such as those that execute bytecode or low-code/no-code application platforms.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="operating-system">
+                <xs:annotation>
+                    <xs:documentation>A software operating system without regard to deployment model
+                        (i.e. installed on physical hardware, virtual machine, image, etc) Refer to
+                        https://en.wikipedia.org/wiki/Operating_system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device">
+                <xs:annotation>
+                    <xs:documentation>A hardware device such as a processor, or chip-set. A hardware device
+                        containing firmware SHOULD include a component for the physical hardware itself, and another
+                        component of type 'firmware' or 'operating-system' (whichever is relevant), describing
+                        information about the software running on the device.
+                        See also the list of known device properties: https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device-driver">
+                <xs:annotation>
+                    <xs:documentation>A special type of software that operates or controls a particular type of device.
+                        Refer to https://en.wikipedia.org/wiki/Device_driver</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="firmware">
+                <xs:annotation>
+                    <xs:documentation>A special type of software that provides low-level control over a devices
+                        hardware. Refer to https://en.wikipedia.org/wiki/Firmware</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="file">
+                <xs:annotation>
+                    <xs:documentation>A computer file. Refer to https://en.wikipedia.org/wiki/Computer_file
+                        for information about files.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="machine-learning-model">
+                <xs:annotation>
+                    <xs:documentation>A model based on training data that can make predictions or decisions without
+                        being explicitly programmed to do so.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="data">
+                <xs:annotation>
+                    <xs:documentation>A collection of discrete values that convey information.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cryptographic-asset">
+                <xs:annotation>
+                    <xs:documentation>A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="hashAlg">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MD5"/>
+            <xs:enumeration value="SHA-1"/>
+            <xs:enumeration value="SHA-256"/>
+            <xs:enumeration value="SHA-384"/>
+            <xs:enumeration value="SHA-512"/>
+            <xs:enumeration value="SHA3-256"/>
+            <xs:enumeration value="SHA3-384"/>
+            <xs:enumeration value="SHA3-512"/>
+            <xs:enumeration value="BLAKE2b-256"/>
+            <xs:enumeration value="BLAKE2b-384"/>
+            <xs:enumeration value="BLAKE2b-512"/>
+            <xs:enumeration value="BLAKE3"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="licenseTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="academic">
+                <xs:annotation>
+                    <xs:documentation>A license that grants use of software solely for the purpose
+                        of education or research.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="appliance">
+                <xs:annotation>
+                    <xs:documentation>A license covering use of software embedded in a specific
+                        piece of hardware.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="client-access">
+                <xs:annotation>
+                    <xs:documentation>A Client Access License (CAL) allows client computers to access
+                        services provided by server software.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="concurrent-user">
+                <xs:annotation>
+                    <xs:documentation>A Concurrent User license (aka floating license) limits the
+                        number of licenses for a software application and licenses are shared among
+                        a larger number of users.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="core-points">
+                <xs:annotation>
+                    <xs:documentation>A license where the core of a computer's processor is assigned
+                        a specific number of points.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="custom-metric">
+                <xs:annotation>
+                    <xs:documentation>A license for which consumption is measured by non-standard
+                        metrics.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="device">
+                <xs:annotation>
+                    <xs:documentation>A license that covers a defined number of installations on
+                        computers and other types of devices.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="evaluation">
+                <xs:annotation>
+                    <xs:documentation>A license that grants permission to install and use software
+                        for trial purposes.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="named-user">
+                <xs:annotation>
+                    <xs:documentation>A license that grants access to the software to one or more
+                        pre-defined users.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="node-locked">
+                <xs:annotation>
+                    <xs:documentation>A license that grants access to the software on one or more
+                        pre-defined computers or devices.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="oem">
+                <xs:annotation>
+                    <xs:documentation>An Original Equipment Manufacturer license that is delivered
+                        with hardware, cannot be transferred to other hardware, and is valid for the
+                        life of the hardware.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="perpetual">
+                <xs:annotation>
+                    <xs:documentation>A license where the software is sold on a one-time basis and
+                        the licensee can use a copy of the software indefinitely.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="processor-points">
+                <xs:annotation>
+                    <xs:documentation>A license where each installation consumes points per
+                        processor.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="subscription">
+                <xs:annotation>
+                    <xs:documentation>A license where the licensee pays a fee to use the software
+                        or service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="user">
+                <xs:annotation>
+                    <xs:documentation>A license that grants access to the software or service by a
+                        specified number of users.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Another license type.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="hashValue">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="([a-fA-F0-9]{32})|([a-fA-F0-9]{40})|([a-fA-F0-9]{64})|([a-fA-F0-9]{96})|([a-fA-F0-9]{128})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="mimeType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[-+a-z0-9.]+/[-+a-z0-9.]+"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encoding">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="base64"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cpe">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Define the format for acceptable CPE URIs. Supports CPE 2.2 and CPE 2.3 formats.
+                Refer to https://nvd.nist.gov/products/cpe for official specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!&quot;#$$%&amp;'\(\)\+,/:;&lt;=&gt;@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="swidType">
+        <xs:sequence>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies the full content of the SWID tag.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to the SWID file.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="tagId" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Maps to the tagId of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Maps to the name of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="version" type="xs:string" use="optional" default="0.0">
+            <xs:annotation>
+                <xs:documentation>Maps to the version of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tagVersion" type="xs:integer" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>Maps to the tagVersion of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="patch" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>Maps to the patch of a SoftwareIdentity.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="urnUuid">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a string representation of a UUID conforming to RFC 4122.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="urn:uuid:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="externalReferenceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="vcs">
+                <xs:annotation>
+                    <xs:documentation>Version Control System</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="issue-tracker">
+                <xs:annotation>
+                    <xs:documentation>Issue or defect tracking system, or an Application Lifecycle Management (ALM) system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="website">
+                <xs:annotation>
+                    <xs:documentation>Website</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="advisories">
+                <xs:annotation>
+                    <xs:documentation>Security advisories</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bom">
+                <xs:annotation>
+                    <xs:documentation>Bill-of-materials (SBOM, OBOM, HBOM, SaaSBOM, etc)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mailing-list">
+                <xs:annotation>
+                    <xs:documentation>Mailing list or discussion group</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="social">
+                <xs:annotation>
+                    <xs:documentation>Social media account</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="chat">
+                <xs:annotation>
+                    <xs:documentation>Real-time chat platform</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="documentation">
+                <xs:annotation>
+                    <xs:documentation>Documentation, guides, or how-to instructions</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="support">
+                <xs:annotation>
+                    <xs:documentation>Community or commercial support</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="source-distribution">
+                <xs:annotation>
+                    <xs:documentation>The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="distribution">
+                <xs:annotation>
+                    <xs:documentation>Direct or repository download location</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="distribution-intake">
+                <xs:annotation>
+                    <xs:documentation>The location where a component was published to. This is often the same as "distribution" but may also include specialized publishing processes that act as an intermediary</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="license">
+                <xs:annotation>
+                    <xs:documentation>
+                        The URL to the license file. If a license URL has been defined in the license
+                        node, it should also be defined as an external reference for completeness.
+                        Example: https://www.apache.org/licenses/LICENSE-2.0.txt
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build-meta">
+                <xs:annotation>
+                    <xs:documentation>Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build-system">
+                <xs:annotation>
+                    <xs:documentation>URL to an automated build system</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="release-notes">
+                <xs:annotation>
+                    <xs:documentation>URL to release notes</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="security-contact">
+                <xs:annotation>
+                    <xs:documentation>Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="model-card">
+                <xs:annotation>
+                    <xs:documentation>A model card describes the intended uses of a machine learning model, potential
+                        limitations, biases, ethical considerations, training parameters, datasets used to train the
+                        model, performance metrics, and other relevant data useful for ML transparency.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="log">
+                <xs:annotation>
+                    <xs:documentation>A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="configuration">
+                <xs:annotation>
+                    <xs:documentation>Parameters or settings that may be used by other components or services.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="evidence">
+                <xs:annotation>
+                    <xs:documentation>Information used to substantiate a claim.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="formulation">
+                <xs:annotation>
+                    <xs:documentation>Describes how a component or service was manufactured or deployed.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="attestation">
+                <xs:annotation>
+                    <xs:documentation>Human or machine-readable statements containing facts, evidence, or testimony</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="threat-model">
+                <xs:annotation>
+                    <xs:documentation>An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="adversary-model">
+                <xs:annotation>
+                    <xs:documentation>The defined assumptions, goals, and capabilities of an adversary.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="risk-assessment">
+                <xs:annotation>
+                    <xs:documentation>Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="vulnerability-assertion">
+                <xs:annotation>
+                    <xs:documentation>A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="exploitability-statement">
+                <xs:annotation>
+                    <xs:documentation>A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="pentest-report">
+                <xs:annotation>
+                    <xs:documentation>Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="static-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dynamic-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="runtime-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>Report generated by analyzing the call stack of a running application</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="component-analysis-report">
+                <xs:annotation>
+                    <xs:documentation>Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="maturity-report">
+                <xs:annotation>
+                    <xs:documentation>Report containing a formal assessment of an organization, business unit, or team against a maturity model</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="certification-report">
+                <xs:annotation>
+                    <xs:documentation>Industry, regulatory, or other certification from an accredited (if applicable) certification body</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="quality-metrics">
+                <xs:annotation>
+                    <xs:documentation>Report or system in which quality metrics can be obtained</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="codified-infrastructure">
+                <xs:annotation>
+                    <xs:documentation>Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="poam">
+                <xs:annotation>
+                    <xs:documentation>Plans of Action and Milestones (POA&amp;M) complement an "attestation" external reference. POA&amp;M is defined by NIST as a "document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones".</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="electronic-signature">
+                <xs:annotation>
+                    <xs:documentation>An e-signature is commonly a scanned representation of a written signature or a stylized script of the persons name.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="digital-signature">
+                <xs:annotation>
+                    <xs:documentation>A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rfc-9116">
+                <xs:annotation>
+                    <xs:documentation>Document that complies with RFC-9116 (A File Format to Aid in Security Vulnerability Disclosure)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Use this if no other types accurately describe the purpose of the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="externalReferences">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                External references provide a way to document systems, sites, and information that may be
+                relevant, but are not included with the BOM. They may also establish specific relationships
+                within or external to the BOM.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="reference" type="bom:externalReference">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Zero or more external references can be defined</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="externalReference">
+        <xs:sequence>
+            <xs:element name="url" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The URI (URL or URN) to the external reference. External references
+                        are URIs and therefore can accept any URL scheme including https, mailto, tel, and dns.
+                        External references may also include formally registered URNs such as CycloneDX BOM-Link to
+                        reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external
+                        references into relationships that can be expressed in a BOM or across BOMs. Refer to:
+                        https://cyclonedx.org/capabilities/bomlink/</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:anyURI bom:bomLinkType"/>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">An optional comment describing the external reference</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hashes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="hash" type="bom:hashType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:externalReferenceType" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the type of external reference. There are built-in types to describe common
+                    references. If a type does not exist for the reference being referred to, use the "other" type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="commitsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Zero or more commits can be specified.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="commit" type="bom:commitType">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies an individual commit.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="commitType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A unique identifier of the commit. This may be version control
+                        specific. For example, Subversion uses revision numbers whereas git uses commit hashes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The URL to the commit. This URL will typically point to a commit
+                        in a version control system.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="author" type="bom:identifiableActionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The author who created the changes in the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="committer" type="bom:identifiableActionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The person who committed or pushed the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="message" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The text description of the contents of the commit</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patchesType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Zero or more patches can be specified.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="patch" type="bom:patchType">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies an individual patch.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="patchType">
+        <xs:sequence>
+            <xs:element name="diff" type="bom:diffType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The patch file (or diff) that show changes.
+                        Refer to https://en.wikipedia.org/wiki/Diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resolves" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="issue" type="bom:issueType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:patchClassification" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the purpose for the patch including the resolution of defects,
+                    security issues, or new behavior or functionality</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="patchClassification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="unofficial">
+                <xs:annotation>
+                    <xs:documentation>A patch which is not developed by the creators or maintainers of the software
+                        being patched. Refer to https://en.wikipedia.org/wiki/Unofficial_patch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="monkey">
+                <xs:annotation>
+                    <xs:documentation>A patch which dynamically modifies runtime behavior.
+                        Refer to https://en.wikipedia.org/wiki/Monkey_patch</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="backport">
+                <xs:annotation>
+                    <xs:documentation>A patch which takes code from a newer version of software and applies
+                        it to older versions of the same software. Refer to https://en.wikipedia.org/wiki/Backporting</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cherry-pick">
+                <xs:annotation>
+                    <xs:documentation>A patch created by selectively applying commits from other versions or
+                        branches of the same software.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="issueClassification">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="defect">
+                <xs:annotation>
+                    <xs:documentation>A fault, flaw, or bug in software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="enhancement">
+                <xs:annotation>
+                    <xs:documentation>A new feature or behavior in software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="security">
+                <xs:annotation>
+                    <xs:documentation>A special type of defect which impacts security</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="diffType">
+        <xs:sequence>
+            <xs:element name="text" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies the optional text of the diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Specifies the URL to the diff</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="issueType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual issue that has been resolved.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The identifier of the issue assigned by the source of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The name of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A description of the issue</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            The source of the issue where it is documented.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="name" minOccurs="0" type="xs:normalizedString" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The name of the source. For example "National Vulnerability Database",
+                                    "NVD", and "Apache"
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="url" minOccurs="0" type="xs:anyURI" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The url of the issue documentation as provided by the source
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        A collection of URL's for reference. Multiple URLs are allowed.
+                        Example: "https://example.com"
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="url" type="xs:anyURI"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="type" type="bom:issueClassification" use="required">
+            <xs:annotation>
+                <xs:documentation>Specifies the type of issue</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="identifiableActionType">
+        <xs:sequence>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The timestamp in which the action occurred</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The name of the individual who performed the action</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">The email address of the individual who performed the action</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="pedigreeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Component pedigree is a way to document complex supply chain scenarios where components are created,
+                distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing
+                this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to
+                document variants where the exact relation may not be known.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="ancestors" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Describes zero or more components in which a component is derived
+                        from. This is commonly used to describe forks from existing projects where the forked version
+                        contains a ancestor node containing the original component it was forked from. For example,
+                        Component A is the original component. Component B is the component being used and documented
+                        in the BOM. However, Component B contains a pedigree node with a single ancestor documenting
+                        Component A - the original component from which Component B is derived from.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="descendants" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Descendants are the exact opposite of ancestors. This provides a
+                        way to document all forks (and their forks) of an original or root component.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="variants" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Variants describe relations where the relationship between the
+                        components are not known. For example, if Component A contains nearly identical code to
+                        Component B. They are both related, but it is unclear if one is derived from the other,
+                        or if they share a common ancestor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="commits" type="bom:commitsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A list of zero or more commits which provide a trail describing
+                        how the component deviates from an ancestor, descendant, or variant.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="patches" type="bom:patchesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">A list of zero or more patches describing how the component
+                        deviates from an ancestor, descendant, or variant. Patches may be complementary to commits
+                        or may be used in place of commits.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Notes, observations, and other non-structured commentary
+                        describing the components pedigree.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dependencyType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependency" type="bom:dependencyType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>The component or service that is a dependency of this dependency object.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="provides" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The component or service that define a given specification or standard, which is provided or implemented by this dependency object.
+                        For example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="ref" type="bom:refLinkType" use="required">
+                        <xs:annotation>
+                            <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="ref" type="bom:refLinkType" use="required">
+            <xs:annotation>
+                <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="dependenciesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependency" type="bom:dependencyType">
+                <xs:annotation>
+                    <xs:documentation>Defines the direct dependencies of a component or service. Components or services
+                        that do not have their own dependencies must be declared as empty elements within the graph.
+                        Components or services that are not represented in the dependency graph may have unknown
+                        dependencies. It is recommended that implementations assume this to be opaque and not an
+                        indicator of a object being dependency-free. It is recommended to leverage compositions to
+                        indicate unknown dependency graphs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="servicesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="service" type="bom:service"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="service">
+        <xs:sequence>
+            <xs:element name="provider" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that provides the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="group" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The grouping name, namespace, or identifier. This will often be a shortened,
+                        single name of the company or project that produced the service or domain name.
+                        Whitespace and special characters should be avoided.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the service. This will often be a shortened, single name
+                        of the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="bom:versionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The service version.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies a description for the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="endpoints" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The endpoint URIs of the service. Multiple endpoints are allowed.
+                        Example: "https://example.com/api/v1/ticker"
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="endpoint" type="xs:anyURI" minOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A service endpoint URI.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="authenticated" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A boolean value indicating if the service requires authentication.
+                        A value of true indicates the service requires authentication prior to use.
+                        A value of false indicates the service does not require authentication.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="x-trust-boundary" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A boolean value indicating if use of the service crosses a trust zone or boundary.
+                        A value of true indicates that by using the service, a trust boundary is crossed.
+                        A value of false indicates that by using the service, a trust boundary is not crossed.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="trustZone" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the trust zone the service resides in.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies information about the data including the directional flow of data and the data classification.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="classification" type="bom:dataClassificationType">
+                                <xs:annotation>
+                                    <xs:documentation>DEPRECATED: Specifies the data classification. THIS FIELD IS DEPRECATED AS OF v1.5. Use dataflow\classification instead</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:element name="dataflow" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>Specifies the data classification.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="classification" type="bom:dataClassificationType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Specifies the data classification.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
+                                    <xs:element name="source" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The URI, URL, or BOM-Link of the components or services the data came in from.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="url">
+                                                    <xs:simpleType>
+                                                        <xs:union memberTypes="xs:anyURI bom:bomLinkElementType"/>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="destination" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The URI, URL, or BOM-Link of the components or services the data is sent to.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="url">
+                                                    <xs:simpleType>
+                                                        <xs:union memberTypes="xs:anyURI bom:bomLinkElementType"/>
+                                                    </xs:simpleType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Name for the defined data.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="description" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Short description of the data content and usage.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##any" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the service.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="services" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of services included or deployed behind the parent service. This is not a dependency
+                        tree. It provides a way to specify a hierarchical representation of service assemblies.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="service" type="bom:service"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="releaseNotes" type="bom:releaseNotesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Specifies optional release notes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the service elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="dataClassificationType">
+        <xs:annotation>
+            <xs:documentation>Specifies the data classification.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="flow" type="bom:dataFlowType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Specifies the flow direction of the data.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="dataFlowType">
+        <xs:annotation>
+            <xs:documentation>Specifies the flow direction of the data. Valid values are:
+                inbound, outbound, bi-directional, and unknown. Direction is relative to the service.
+                Inbound flow states that data enters the service. Outbound flow states that data
+                leaves the service. Bi-directional states that data flows both ways, and unknown
+                states that the direction is not known.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="inbound">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data that enters a service.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="outbound">
+                <xs:annotation>
+                    <xs:documentation>Data that exits a service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bi-directional">
+                <xs:annotation>
+                    <xs:documentation>Data flows in and out of the service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The directional flow of data is not known.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="licenseChoiceType">
+        <xs:choice>
+            <xs:element name="license" type="bom:licenseType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="expression" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A valid SPDX license expression.
+                        Refer to https://spdx.org/specifications for syntax requirements
+
+                        Example values:
+                        - Apache-2.0 AND (MIT OR GPL-2.0-only)
+                        - GPL-3.0-only WITH Classpath-exception-2.0
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:normalizedString">
+                            <xs:attribute name="bom-ref" type="bom:refType">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        An optional identifier which can be used to reference the license elsewhere in the BOM.
+                                        Uniqueness is enforced within all elements and children of the root-level bom element.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="acknowledgement" type="bom:licenseAcknowledgementEnumerationType">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Declared licenses and concluded licenses represent two different stages in the
+                                        licensing process within software development. Declared licenses refer to the
+                                        initial intention of the software authors regarding the licensing terms under
+                                        which their code is released. On the other hand, concluded licenses are the
+                                        result of a comprehensive analysis of the project's codebase to identify and
+                                        confirm the actual licenses of the components used, which may differ from the
+                                        initially declared licenses. While declared licenses provide an upfront indication
+                                        of the licensing intentions, concluded licenses offer a more thorough understanding
+                                        of the actual licensing within a project, facilitating proper compliance and risk
+                                        management. Observed licenses are defined in `evidence.licenses`. Observed licenses
+                                        form the evidence necessary to substantiate a concluded license.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:simpleType name="licenseAcknowledgementEnumerationType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="declared">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Declared licenses represent the initial intentions of authors regarding
+                            the licensing terms of their code.
+                        </xs:documentation>
+                    </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="concluded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Concluded licenses are verified and confirmed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="copyrightsType">
+        <xs:sequence>
+            <xs:element name="text" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="identityFieldType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="group"/>
+            <xs:enumeration value="name"/>
+            <xs:enumeration value="version"/>
+            <xs:enumeration value="purl"/>
+            <xs:enumeration value="cpe"/>
+            <xs:enumeration value="omniborId"/>
+            <xs:enumeration value="swhid"/>
+            <xs:enumeration value="swid"/>
+            <xs:enumeration value="hash"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="decimalPercentType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="evidenceTechnique">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="source-code-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines the source code without executing it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="binary-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines a compiled binary through reverse engineering, typically via disassembly or bytecode reversal.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="manifest-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines a package management system such as those used for building software or installing software.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ast-fingerprint">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines the Abstract Syntax Tree (AST) of source code or a compiled binary.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="hash-comparison">
+                <xs:annotation>
+                    <xs:documentation>
+                        Evaluates the cryptographic hash of a component against a set of pre-computed hashes of identified software.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="instrumentation">
+                <xs:annotation>
+                    <xs:documentation>
+                        Examines the call stack of running applications by intercepting and monitoring application logic without the need to modify the application.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dynamic-analysis">
+                <xs:annotation>
+                    <xs:documentation>
+                        Evaluates a running application.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="filename">
+                <xs:annotation>
+                    <xs:documentation>
+                        Evaluates file name of a component against a set of known file names of identified software.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="attestation">
+                <xs:annotation>
+                    <xs:documentation>
+                        A testimony to the accuracy of the identify of a component made by an individual or entity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>
+                        Any other technique.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="componentEvidenceType">
+        <xs:sequence>
+            <xs:element name="identity" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Evidence that substantiates the identity of a component. The identify may be an
+                        object or an array of identity objects. Support for specifying identity as a single object was
+                        introduced in CycloneDX v1.5. "unbounded" was introduced in v1.6. It is recommended that all
+                        implementations are aware of "unbounded".</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="field" type="bom:identityFieldType" minOccurs="1" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The identity field of the component which the evidence describes.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="confidence" type="bom:decimalPercentType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="concludedValue" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available).</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="methods" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The methods used to extract and/or analyze the evidence.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="method" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="technique" type="bom:evidenceTechnique" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The technique used in this method of analysis.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="confidence" type="bom:decimalPercentType" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The value or contents of the evidence.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The object in the BOM identified by its bom-ref. This is often a component or service,
+                                    but may be any object type supporting bom-refs. Tools used for analysis should already
+                                    be defined in the BOM, either in the metadata/tools, components, or formulation.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="tool" type="bom:bomReferenceType" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="occurrences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Evidence of individual instances of a component spread across multiple locations.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="occurrence" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="location" type="xs:string" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The location or path to where the component was found.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="line" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The line number where the component was found.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="offset" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The offset where the component was found.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="symbol" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The symbol name that was found associated with the component.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="additionalContext" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Any additional context of the detected component (e.g. a code snippet).</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An optional identifier which can be used to reference the occurrence elsewhere
+                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="callstack" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Evidence of the components use through the callstack.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="frames" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="frame" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="package" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>A package organizes modules into namespaces, providing a unique namespace for each type it contains.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="module" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>A module or class that encloses functions/methods and other code.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="function" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>A block of code designed to perform a particular task.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="parameters" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Optional arguments that are passed to the module or function.</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="parameter" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="line" type="xs:integer" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The line number the code that is called resides on.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="column" type="xs:integer" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The column the code that is called resides.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="fullFilename" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The full path and filename of the module.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The object in the BOM identified by its bom-ref. This is often a component or service,
+                                    but may be any object type supporting bom-refs. Tools used for analysis should already
+                                    be defined in the BOM, either in the metadata/tools, components, or formulation.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="tool" type="bom:bomReferenceType" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" type="bom:licenseChoiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="copyright" type="bom:copyrightsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Copyright evidence captures intellectual property assertions, providing evidence of possible ownership and legal protection.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="compositionsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="composition" type="bom:compositionType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="compositionType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="aggregate" type="bom:aggregateType" default="not_specified">
+                <xs:annotation>
+                    <xs:documentation>Specifies an aggregate type that describes how complete a relationship is.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="assemblies" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the components or services being described. Assemblies refer to
+                        nested relationships whereby a constituent part may include other constituent parts. References
+                        do not cascade to child parts. References are explicit for the specified constituent part only.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="assembly" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dependencies" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the components or services being described. Dependencies refer to a
+                        relationship whereby an independent constituent part requires another independent constituent
+                        part. References do not cascade to transitive dependencies. References are explicit for the
+                        specified dependency only.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="dependency" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="vulnerabilities" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The bom-ref identifiers of the vulnerabilities being described.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="vulnerability" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the composition elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="aggregateType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="complete">
+                <xs:annotation>
+                    <xs:documentation>The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_proprietary_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_first_party_opensource_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_proprietary_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="incomplete_third_party_opensource_only">
+                <xs:annotation>
+                    <xs:documentation>The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="not_specified">
+                <xs:annotation>
+                    <xs:documentation>The relationship completeness is not specified.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="localeType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a syntax for representing two character language code (ISO-639) followed by an optional two
+                character country code. The language code must be lower case. If the country code is specified, the
+                country code must be upper case. The language code and country code must be separated by a minus sign.
+                Examples: en, en-US, fr, fr-CA
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([a-z]{2})(-[A-Z]{2})?"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="releaseNotesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="type" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The software versioning type. It is recommended that the release type use one
+                        of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software
+                        release types is not practical, so standardizing on the recommended values, whenever possible,
+                        is strongly encouraged.
+                        * major = A major release may contain significant changes or may introduce breaking changes.
+                        * minor = A minor release, also known as an update, may contain a smaller number of changes than major releases.
+                        * patch = Patch releases are typically unplanned and may resolve defects or important security issues.
+                        * pre-release = A pre-release may include alpha, beta, or release candidates and typically have
+                          limited support. They provide the ability to preview a release prior to its general availability.
+                        * internal = Internal releases are not for public consumption and are intended to be used exclusively
+                          by the project or manufacturer that produced it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The title of the release.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="featuredImage" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to an image that may be prominently displayed with the release note.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="socialImage" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The URL to an image that may be used in messaging on social media platforms.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A short description of the release.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the release note was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="aliases" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="alias" type="xs:normalizedString">
+                            <xs:annotation>
+                                <xs:documentation>One or more alternate names the release may be referred to. This may
+                                include unofficial terms used by development and marketing teams (e.g. code names).</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tags" type="bom:tagsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="resolves" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A collection of issues that have been resolved.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="issue" type="bom:issueType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="notes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="note">
+                            <xs:annotation>
+                                <xs:documentation>Zero or more release notes containing the locale and content. Multiple
+                                note elements may be specified to support release notes in a wide variety of languages.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="locale" type="bom:localeType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The ISO-639 (or higher) language code and optional ISO-3166
+                                                (or higher) country code. Examples include: "en", "en-US", "fr" and "fr-CA".</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="text" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Specifies the full content of the release note.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="modelCardType">
+        <!--
+        Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and
+        available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json.
+        In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and
+        available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.
+        -->
+        <xs:annotation>
+            <xs:documentation>
+                A model card describes the intended uses of a machine learning model and potential limitations, including
+                biases and ethical considerations. Model cards typically contain the training parameters, which datasets
+                were used to train the model, performance metrics, and other relevant data useful for ML transparency.
+                This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified
+                for other component types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="modelParameters" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Hyper-parameters for construction of the model.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="approach" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The overall approach to learning used by the model for problem solving.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="type" type="bom:machineLearningApproachType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Learning types describing the learning problem or hybrid learning problem.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="task" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Directly influences the input and/or output. Examples include classification,
+                                    regression, clustering, etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="architectureFamily" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The model architecture family such as transformer network, convolutional neural
+                                    network, residual neural network, LSTM neural network, etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="modelArchitecture" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="datasets" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The datasets used to train and evaluate the model.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>References a data component by the components bom-ref attribute</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="dataset" type="bom:componentDataType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Inline Data Information</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The input format(s) of the model
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="input" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="format" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The data format for input to the model. Example formats include string, image, time-series
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The output format(s) from the model
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="output" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="format" type="xs:string" minOccurs="1" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The data format for output from the model. Example formats include string, image, time-series
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="quantitativeAnalysis" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A quantitative analysis of the model
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="performanceMetrics" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="performanceMetric" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The type of performance metric.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The value of the performance metric.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="slice" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The name of the slice this metric was computed on. By default, assume
+                                                            this metric is not sliced.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="confidenceInterval" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The confidence interval of the metric.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="lowerBound" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The lower bound of the confidence interval.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="upperBound" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The upper bound of the confidence interval.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="graphics" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A collection of graphics that represent various measurements
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A description of this collection of graphics.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="collection" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A collection of graphics.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="graphic" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The name of the graphic.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="image" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The graphic (vector or raster). Base64 encoding must be specified for binary images.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="considerations" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        What considerations should be taken into account regarding the model's construction, training,
+                        and application?
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="users" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Who are the intended users of the model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="user" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="useCases" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the intended use cases of the model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="useCase" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="technicalLimitations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the known technical limitations of the model? E.g. What kind(s) of data
+                                    should the model be expected not to perform well on? What are the factors that might
+                                    degrade model performance?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="technicalLimitation" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="performanceTradeoffs" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the known tradeoffs in accuracy/performance of the model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="performanceTradeoff" type="xs:string" minOccurs="0" maxOccurs="1" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ethicalConsiderations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the ethical risks involved in the application of this model?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="ethicalConsideration" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The name of the risk
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="mitigationStrategy" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Strategy used to address this risk
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="environmentalConsiderations" type="bom:environmentalConsiderationsType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="fairnessAssessments" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    How does the model affect groups at risk of being systematically disadvantaged?
+                                    What are the harms and benefits to the various affected groups?
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="fairnessAssessment" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="groupAtRisk" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The groups or individuals at risk of being systematically disadvantaged by the model.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="benefits" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Expected benefits to the identified groups.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="harms" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Expected harms to the identified groups.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="mitigationStrategy" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            With respect to the benefits and harms outlined, please
+                                                            describe any mitigation strategy implemented.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the model card elsewhere in the BOM.
+                    Every bom-ref must be unique within the BOM.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="environmentalConsiderationsType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes various environmental impact metrics.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="energyConsumptions" type="bom:energyConsumptionsType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Describes energy consumption information incurred for one or more component lifecycle activities.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="energyConsumptionsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="energyConsumption" type="bom:energyConsumptionType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="energyConsumptionType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes energy consumption information incurred for the specified lifecycle activity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="activity" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The type of activity that is part of a machine learning model development or operational lifecycle.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="design">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model design including problem framing, goal definition and algorithm selection.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="data-collection">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model data acquisition including search, selection and transfer.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="data-preparation">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model data preparation including data cleaning, labeling and conversion.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="training">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model building, training and generalized tuning.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="fine-tuning">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    refining a trained model to produce desired outputs for a given problem space.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="validation">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    model validation including model output evaluation and testing.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="deployment">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    explicit model deployment to a target hosting infrastructure.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="inference">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    generating an output response from a hosted model from a set of inputs.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="other">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    a lifecycle activity type whose description does not match currently defined values.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="energyProviders" type="bom:energyProviderType" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        The provider(s) of the energy consumed by the associated model development lifecycle activity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="activityEnergyCost" type="bom:energyMeasureType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The total energy cost associated with the model lifecycle activity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="co2CostEquivalent" type="bom:co2MeasureType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The CO2 cost (debit) equivalent to the total energy cost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="co2CostOffset" type="bom:co2MeasureType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The CO2 offset (credit) for the CO2 equivalent cost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="energyMeasureType">
+        <xs:annotation>
+            <xs:documentation>
+                A measure of energy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="xs:decimal" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Quantity of energy.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="unit" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unit of energy.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="kWh">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="co2MeasureType">
+        <xs:annotation>
+            <xs:documentation>
+                A measure of carbon dioxide (CO2).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="xs:decimal" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Quantity of carbon dioxide (CO2).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="unit" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unit of carbon dioxide (CO2).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="tCO2eq">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Tonnes (t) of carbon dioxide (CO2) equivalent (eq).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="energyProviderType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the physical provider of energy used for model development or operations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the energy provider.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The organization of the energy provider.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="energySource" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The energy source for the energy provider.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="coal">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced by types of coal.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="oil">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Petroleum products (primarily crude oil and its derivative fuel oils).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="natural-gas">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="nuclear">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="wind">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from moving air.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="solar">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from the sun (i.e., solar radiation).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="geothermal">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from heat within the earth.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="hydropower">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Energy produced from flowing water.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="biofuel">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="unknown">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The energy source is unknown.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="other">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An energy source that is not listed.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="energyProvided" type="bom:energyMeasureType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The energy provided by the energy source for an associated activity.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the energy provider elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="postalAddressType">
+        <xs:annotation>
+            <xs:documentation>
+                An address used to identify a contactable location.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="country" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The country name or the two-letter ISO 3166-1 country code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="region" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The region or state in the country. For example, Texas.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="locality" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The locality or city within the country. For example, Austin.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="postOfficeBoxNumber" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The post office box number. For example, 901.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="postalCode" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The postal code. For example, 78758.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="streetAddress" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The street address. For example, 100 Main Street.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the address elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="machineLearningApproachType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="supervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Supervised machine learning involves training an algorithm on labeled
+                        data to predict or classify new data based on the patterns learned from
+                        the labeled examples.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unsupervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unsupervised machine learning involves training algorithms on unlabeled
+                        data to discover patterns, structures, or relationships without explicit
+                        guidance, allowing the model to identify inherent structures or clusters
+                        within the data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="reinforcement-learning">
+                <xs:annotation>
+                    <xs:documentation>
+                        Reinforcement learning is a type of machine learning where an agent learns
+                        to make decisions by interacting with an environment to maximize cumulative
+                        rewards, through trial and error.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="semi-supervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Semi-supervised machine learning utilizes a combination of labeled and
+                        unlabeled data during training to improve model performance, leveraging
+                        the benefits of both supervised and unsupervised learning techniques.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="self-supervised">
+                <xs:annotation>
+                    <xs:documentation>
+                        Self-supervised machine learning involves training models to predict parts
+                        of the input data from other parts of the same data, without requiring
+                        external labels, enabling learning from large amounts of unlabeled data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="componentDataType">
+        <xs:sequence>
+            <xs:element name="type" type="bom:componentDataTypeEnumeration" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The general theme or subject matter of the data being specified.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the dataset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="contents" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The contents or references to the contents of the data being described.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>An optional way to include textual or encoded data.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The URL to where the data can be retrieved.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>Provides the ability to document name-value parameters used for configuration.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="classification" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sensitiveData" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of any sensitive data in a dataset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="graphics" type="bom:graphicsCollectionType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A collection of graphics that represent various measurements.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the dataset. Can describe size of dataset, whether it's used for source code,
+                        training, testing, or validation, etc.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the dataset elsewhere in the BOM.
+                    Every bom-ref must be unique within the BOM.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="dataGovernance">
+        <xs:sequence>
+            <xs:element name="custodians" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data custodians are responsible for the safe custody, transport, and storage of data.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="custodian" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="stewards" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data stewards are responsible for data content, context, and associated business rules.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="steward" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="owners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data owners are concerned with risk and appropriate access to data.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="owner" type="bom:organizationOrIndividualType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="organizationOrIndividualType">
+        <xs:choice>
+            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1" />
+            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="graphicsCollectionType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of graphics that represent various measurements.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="description" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of this collection of graphics.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="collection" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A collection of graphics.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="graphic" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The name of the graphic.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="image" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The graphic (vector or raster). Base64 encoding must be specified for binary images.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="componentDataTypeEnumeration">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="source-code">
+                <xs:annotation>
+                    <xs:documentation>Any type of code, code snippet, or data-as-code.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="configuration">
+                <xs:annotation>
+                    <xs:documentation>Parameters or settings that may be used by other components.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset">
+                <xs:annotation>
+                    <xs:documentation>A collection of data.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="definition">
+                <xs:annotation>
+                    <xs:documentation>Data that can be used to create new instances of what the definition defines.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>Any other type of data that does not fit into existing definitions.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="bomReferenceType">
+        <xs:attribute name="ref" use="required">
+            <xs:annotation>
+                <xs:documentation>References a component or service by its bom-ref attribute</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="bom:refLinkType bom:bomLinkType"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="bom:propertyType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:annotation>
+            <xs:documentation>Specifies an individual property with a name and value.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The name of the property. Duplicate names are allowed, each potentially having a different value.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilitiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="vulnerability" type="bom:vulnerabilityType">
+                <xs:annotation>
+                    <xs:documentation>Defines a weakness in a component or service that could be exploited or triggered by a threat source.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilityType">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+            <xs:element name="id" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The identifier that uniquely identifies the vulnerability. For example:
+                        CVE-2021-39182, GHSA-35m5-8cvj-8783, and SNYK-PYTHON-ENROCRYPT-1912876.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The source that published the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="references" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Zero or more pointers to vulnerabilities that are the equivalent of the
+                        vulnerability specified. Often times, the same vulnerability may exist in multiple sources of
+                        vulnerability intelligence, but have different identifiers. References provide a way to
+                        correlate vulnerabilities across multiple sources of vulnerability intelligence.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="reference">
+                            <xs:annotation>
+                                <xs:documentation>A pointer to a vulnerability that is the equivalent of the
+                                    vulnerability specified.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="1" maxOccurs="1">
+                                    <xs:element name="id" type="xs:normalizedString" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The identifier that uniquely identifies the vulnerability. For example:
+                                                CVE-2021-39182, GHSA-35m5-8cvj-8783, and SNYK-PYTHON-ENROCRYPT-1912876.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The source that published the vulnerability.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ratings" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">List of vulnerability ratings. Consumers SHOULD consider ratings in prioritization decisions; source ratings may differ and aid prioritization.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="rating" type="bom:ratingType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cwes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.
+                            For example 399 (of https://cwe.mitre.org/data/definitions/399.html)
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="cwe" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A description of the vulnerability as provided by the source.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="detail" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>If available, an in-depth description of the vulnerability as provided by the
+                        source organization. Details often include information useful in understanding root cause.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="recommendation" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Recommendations of how the vulnerability can be remediated or mitigated.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workaround" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="proofOfConcept" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Evidence used to reproduce the vulnerability.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="reproductionSteps" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>Precise steps to reproduce the vulnerability.</xs:documentation>
+                                </xs:annotation>
+                        </xs:element>
+                        <xs:element name="environment" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A description of the environment in which reproduction was possible.</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="supportingMaterial" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="advisories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Published advisories of the vulnerability if provided.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence>
+                        <xs:element name="advisory" type="bom:advisoryType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="created" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was created in the vulnerability database.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="published" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was first published.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="updated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was last updated.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="rejected" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the vulnerability record was rejected (if applicable).</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="credits" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Individuals or organizations credited with the discovery of the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="organizations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The organizations credited with vulnerability discovery.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="organization" type="bom:organizationalEntity"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="individuals" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>The individuals, not associated with organizations, that are credited with vulnerability discovery.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="individual" type="bom:organizationalContact"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="tools" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool(s) used to identify, confirm, or score the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="tool" minOccurs="0" type="bom:toolType">
+                                <xs:annotation>
+                                    <xs:documentation>DEPRECATED. Use tools\components or tools\services instead.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:sequence minOccurs="0" maxOccurs="1">
+                            <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of software and hardware components used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>A list of services used as tools.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="analysis" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            An assessment of the impact and exploitability of the vulnerability.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                        <xs:element name="state" type="bom:impactAnalysisStateType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="justification" type="bom:impactAnalysisJustificationType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The rationale of why the impact analysis state was asserted.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="responses" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>A response to the vulnerability by the manufacturer, supplier, or
+                                    project responsible for the affected component or service. More than one response
+                                    is allowed. Responses are strongly encouraged for vulnerabilities where the analysis
+                                    state is exploitable.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="response" type="bom:impactAnalysisResponsesType"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="detail" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Detailed description of the impact including methods used during assessment.
+                                    If a vulnerability is not exploitable, this field should include specific details
+                                    on why the component or service is not impacted by this vulnerability.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="firstIssued" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The date and time (timestamp) when the analysis was first issued.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The date and time (timestamp) when the analysis was last updated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="affects" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The components or services that are affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="target">
+                            <xs:complexType>
+                                <xs:sequence minOccurs="0" maxOccurs="1">
+                                    <xs:element name="ref" minOccurs="1" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>References a component or service by the objects bom-ref.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="versions" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Zero or more individual versions or range of versions.</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="version">
+                                                    <xs:complexType>
+                                                        <xs:sequence minOccurs="0" maxOccurs="1">
+                                                            <xs:choice>
+                                                                <xs:element name="version" type="bom:versionType" minOccurs="1" maxOccurs="1">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>A single version of a component or service.</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                                <xs:element name="range" type="bom:versionRangeType" minOccurs="1" maxOccurs="1">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
+                                                            </xs:choice>
+                                                            <xs:element name="status" type="bom:impactAnalysisAffectedStatusType" minOccurs="0" maxOccurs="1" default="affected">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The vulnerability status for the version or range of versions.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the vulnerability elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="vulnerabilitySourceType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="name" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The name of the source.
+                        For example: NVD, National Vulnerability Database, OSS Index, VulnDB, and GitHub Advisories
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The url of the vulnerability documentation as provided by the source.
+                    For example: https://nvd.nist.gov/vuln/detail/CVE-2021-39182</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ratingType">
+        <xs:sequence>
+            <xs:element name="source" type="bom:vulnerabilitySourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The source that calculated the severity or risk rating of the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="score" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The numerical score of the rating.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="severity" type="bom:severityType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Textual representation of the severity that corresponds to the numerical score of the rating.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="method" type="bom:scoreSourceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The risk scoring methodology/standard used.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="vector" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Textual representation of the metric values used to score the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="justification" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>An optional reason for rating the vulnerability as it was.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="advisoryType">
+        <xs:sequence>
+            <xs:element name="title" type="xs:normalizedString" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>An optional name of the advisory.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" type="xs:anyURI" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Location where the advisory can be obtained.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="annotationsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="annotation" type="bom:annotationType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="annotatorChoiceType">
+        <xs:choice>
+            <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="individual" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The person that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="component" type="bom:component" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tool or component that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="service" type="bom:service" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The service that created the annotation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="annotationType">
+        <xs:sequence>
+            <xs:element name="subjects" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The objects in the BOM identified by their bom-ref's. This is often components or services, but may be any object type supporting bom-refs.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="subject" type="bom:bomReferenceType"/>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="annotator" type="bom:annotatorChoiceType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The organization, individual, component, or service which created the textual content
+                        of the annotation.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The date and time (timestamp) when the annotation was created.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="text" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The textual content of the annotation.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the annotation elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="severityType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Textual representation of the severity of the vulnerability adopted by the analysis method. If the
+                analysis method uses values other than what is provided, the user is expected to translate appropriately.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="critical">
+                <xs:annotation>
+                    <xs:documentation>Critical severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="high">
+                <xs:annotation>
+                    <xs:documentation>High severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="medium">
+                <xs:annotation>
+                    <xs:documentation>Medium severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="low">
+                <xs:annotation>
+                    <xs:documentation>Low severity</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="info">
+                <xs:annotation>
+                    <xs:documentation>Informational warning.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation>None</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>The severity is not known</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisStateType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="resolved">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability has been remediated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="resolved_with_pedigree">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability has been remediated and evidence of the changes are provided in the affected
+                        components pedigree containing verifiable commit history and/or diff(s).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="exploitable">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability may be directly or indirectly exploitable.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="in_triage">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability is being investigated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="false_positive">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerability is not specific to the component or service and was falsely identified or associated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="not_affected">
+                <xs:annotation>
+                    <xs:documentation>
+                        The component or service is not affected by the vulnerability. Justification should be specified
+                        for all not_affected cases.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisJustificationType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The rationale of why the impact analysis state was asserted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="code_not_present">
+                <xs:annotation>
+                    <xs:documentation>
+                        The code has been removed or tree-shaked.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="code_not_reachable">
+                <xs:annotation>
+                    <xs:documentation>
+                        The vulnerable code is not invoked at runtime.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_configuration">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a configurable option to be set/unset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_dependency">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a dependency that is not present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="requires_environment">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a certain environment which is not present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_by_compiler">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploitability requires a compiler flag to be set/unset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_at_runtime">
+                <xs:annotation>
+                    <xs:documentation>
+                        Exploits are prevented at runtime.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_at_perimeter">
+                <xs:annotation>
+                    <xs:documentation>
+                        Attacks are blocked at physical, logical, or network perimeter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="protected_by_mitigating_control">
+                <xs:annotation>
+                    <xs:documentation>
+                        Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="scoreSourceType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Specifies the severity or risk scoring methodology or standard used.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CVSSv2">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v2.0 standard as defined at https://www.first.org/cvss/v2/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv3">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v3.0 standard as defined at https://www.first.org/cvss/v3-0/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv31">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v3.1 standard as defined at https://www.first.org/cvss/v3-1/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CVSSv4">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Common Vulnerability Scoring System v4.0 standard as defined at https://www.first.org/cvss/v4-0/
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OWASP">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        OWASP Risk Rating as defined at https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SSVC">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Stakeholder Specific Vulnerability Categorization as defined at https://github.com/CERTCC/SSVC
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Another severity or risk scoring methodology
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisResponsesType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The rationale of why the impact analysis state was asserted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="can_not_fix">
+                <xs:annotation>
+                    <xs:documentation>Can not fix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="will_not_fix">
+                <xs:annotation>
+                    <xs:documentation>Will not fix</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="update">
+                <xs:annotation>
+                    <xs:documentation>Update to a different revision or release</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rollback">
+                <xs:annotation>
+                    <xs:documentation>Revert to a previous revision or release</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="workaround_available">
+                <xs:annotation>
+                    <xs:documentation>There is a workaround available</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="impactAnalysisAffectedStatusType" final="restriction">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The vulnerability status of a given version or range of versions of a product. The statuses
+                'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability.
+                The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected.
+                There can be many reasons for an 'unknown' status, including that an investigation has not been
+                undertaken or that a vendor has not disclosed the status.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="affected">
+                <xs:annotation>
+                    <xs:documentation>The version is affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unaffected">
+                <xs:annotation>
+                    <xs:documentation>The version is not affected by the vulnerability.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unknown">
+                <xs:annotation>
+                    <xs:documentation>It is unknown (or unspecified) whether the given version is affected.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="formulationType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes how a component or service was manufactured or deployed. This is achieved through the use
+                of formulas, workflows, tasks, and steps, which declare the precise steps to reproduce along with the
+                observed formulas describing the steps which transpired in the manufacturing process.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="formula" type="bom:formulaType"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="formulaType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes workflows and resources that captures rules and other aspects of how the associated
+                BOM component or service was formed.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Transient components that are used in tasks that constitute one or more of
+                        this formula's workflows</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Transient services that are used in tasks that constitute one or more of
+                        this formula's workflows</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workflows" type="bom:workflowsType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>List of workflows that can be declared to accomplish specific orchestrated goals
+                        and independently triggered.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the formula elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="workflowsType">
+        <xs:sequence>
+            <xs:element name="workflow" type="bom:workflowType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="workflowType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>References to component or service resources that are used to realize
+                        the resource instance.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tasks" type="bom:tasksType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The tasks that comprise the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="taskDependencies" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The graph of dependencies between tasks within the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="taskTypes" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Indicates the types of activities performed by the set of workflow tasks.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="taskType" type="bom:taskTypeEnum" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="trigger" type="bom:triggerType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>The trigger that initiated the task.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="steps" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The sequence of steps for the task.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="step" type="bom:stepType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Represents resources and data brought into a task at runtime by executor
+                        or task commands</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="input" type="bom:inputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Represents resources and data output from a task at runtime by executor
+                        or task commands</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="output" type="bom:outputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timeStart" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task started.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeEnd" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task ended.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workspaces" type="bom:workspacesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A set of named filesystem or data resource shareable by workflow tasks.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="runtimeTopology" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A graph of the component runtime topology for workflow's instance.
+                        A description of the runtime component and service topology.  This can describe a partial or
+                        complete topology used to host and execute the task (e.g., hardware, operating systems,
+                        configurations, etc.)</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the workflow elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="resourceReferencesType">
+        <xs:sequence>
+            <xs:element name="resourceReference" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="resourceReferenceType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="ref" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            References an object by its bom-ref attribute
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:union memberTypes="bom:refLinkType bom:bomLinkElementType"/>
+                    </xs:simpleType>
+                </xs:element>
+                <xs:element name="externalReference" type="bom:externalReference" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to an externally accessible resource.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="tasksType">
+        <xs:sequence>
+            <xs:element name="task" type="bom:taskType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="taskType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References to component or service resources that are used to realize the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="taskTypes" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates the types of activities performed by the set of workflow tasks.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="taskType" type="bom:taskTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="trigger" type="bom:triggerType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The trigger that initiated the task.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="steps" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The sequence of steps for the task.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="step" type="bom:stepType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data brought into a task at runtime by executor or task commands.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="input" type="bom:inputType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data output from a task at runtime by executor or task commands
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="output" type="bom:outputType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timeStart" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task started.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeEnd" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the task ended.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="workspaces" type="bom:workspacesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A set of named filesystem or data resource shareable by workflow tasks.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="runtimeTopology" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A graph of the component runtime topology for task's instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the task elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="taskTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="copy">
+                <xs:annotation>
+                    <xs:documentation>A task that copies software or data used to accomplish other tasks in the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="clone">
+                <xs:annotation>
+                    <xs:documentation>A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="lint">
+                <xs:annotation>
+                    <xs:documentation>A task that checks source code for programmatic and stylistic errors.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="scan">
+                <xs:annotation>
+                    <xs:documentation>A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="merge">
+                <xs:annotation>
+                    <xs:documentation>A task that merges changes or fixes into source code prior to a build step in the workflow.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="build">
+                <xs:annotation>
+                    <xs:documentation>A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="test">
+                <xs:annotation>
+                    <xs:documentation>A task that verifies the functionality of a component or service.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="deliver">
+                <xs:annotation>
+                    <xs:documentation>A task that delivers a built artifact to one or more target repositories or storage systems.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="deploy">
+                <xs:annotation>
+                    <xs:documentation>A task that deploys a built artifact for execution on one or more target systems.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="release">
+                <xs:annotation>
+                    <xs:documentation>A task that releases a built, versioned artifact to a target repository or distribution system.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="clean">
+                <xs:annotation>
+                    <xs:documentation>A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="other">
+                <xs:annotation>
+                    <xs:documentation>A workflow task that does not match current task type definitions.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="workspacesType">
+        <xs:sequence>
+            <xs:element name="workspace" type="bom:workspaceType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="workspaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem or data resource shareable by workflow tasks.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="aliases" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping
+                        so other tasks can use their own local name in their steps.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="alias" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References to component or service resources that are used to realize the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="accessMode" type="bom:accessModeEnum" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Describes the read-write access control for the workspace relative to the owning resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mountPath" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A path to a location on disk where the workspace will be available to the associated task's steps.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="managedDataType" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of a domain-specific data type the workspace represents. This property is for CI/CD
+                        frameworks that are able to provide access to structured, managed data at a more granular level
+                        than a filesystem.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="volumeRequest" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Identifies the reference to the request for a specific volume type and parameters.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="volume" type="bom:volumeType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Information about the actual volume instance allocated to the workspace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the workflow elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="accessModeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="read-only"/>
+            <xs:enumeration value="read-write"/>
+            <xs:enumeration value="read-write-once"/>
+            <xs:enumeration value="write-once"/>
+            <xs:enumeration value="write-only"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="volumeType">
+        <xs:annotation>
+            <xs:documentation>
+                An identifiable, logical unit of data storage tied to a physical device.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the volume instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the volume instance
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mode" type="bom:volumeModeEnum" minOccurs="0" maxOccurs="1" default="filesystem">
+                <xs:annotation>
+                    <xs:documentation>
+                        The mode for the volume instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="path" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The underlying path created from the actual volume.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sizeAllocated" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The allocated size of the volume accessible to the associated workspace. This should include
+                        the scalar size as well as IEC standard unit in either decimal or binary form.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="persistent" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates if the volume persists beyond the life of the resource it is associated with.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="remote" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates if the volume is remotely (i.e., network) attached.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="volumeModeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="filesystem"/>
+            <xs:enumeration value="block"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="stepType">
+        <xs:annotation>
+            <xs:documentation>
+                Executes specific commands or tools in order to accomplish its owning task as part of a sequence.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A name for the step.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the step.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="commands" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Ordered list of commands or directives for the step
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="command" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="executed" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A text representation of the executed command.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document properties in a name/value store.
+                                                This provides flexibility to include data not officially supported in the standard
+                                                without having to use additional namespaces or create extensions. Property names
+                                                of interest to the general public are encouraged to be registered in the
+                                                CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                                                Formal registration is optional.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="triggerType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier for the resource instance within its deployment context.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resourceReferences" type="bom:resourceReferencesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References to component or service resources that are used to realize the resource instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="type" type="bom:triggerTypeType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The source type of event which caused the trigger to fire.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="event" type="bom:eventType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The event data that caused the associated trigger to activate.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="conditions" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>A list of conditions used to determine if a trigger should be activated.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="condition" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A condition that was used to determine a trigger should be activated.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Describes the set of conditions which cause the trigger to activate.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="expression" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The logical expression that was evaluated that determined the trigger should be fired.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document properties in a name/value store.
+                                                This provides flexibility to include data not officially supported in the standard
+                                                without having to use additional namespaces or create extensions. Property names
+                                                of interest to the general public are encouraged to be registered in the
+                                                CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                                                Formal registration is optional.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timeActivated" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the trigger was activated.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="inputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data brought into a task at runtime by executor or task commands
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="input" type="bom:inputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Represents resources and data output from a task at runtime by executor or task commands
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="output" type="bom:outputType" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the trigger elsewhere in the BOM.
+                    Uniqueness is enforced within all elements and children of the root-level bom element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="triggerTypeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="manual"/>
+            <xs:enumeration value="api"/>
+            <xs:enumeration value="webhook"/>
+            <xs:enumeration value="scheduled"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="eventType">
+        <xs:sequence>
+            <xs:element name="uid" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The unique identifier of the event.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A description of the event.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="timeReceived" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The date and time (timestamp) when the event was received.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Encoding of the raw event data.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References the component or service that was the source of the event
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="target" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        References the component or service that was the target of the event
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="inputType">
+        <xs:annotation>
+            <xs:documentation>
+                Type that represents various input data types and formats.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="resource" type="bom:resourceReferenceType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to an independent resource provided as an input to a task by the workflow runtime.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="parameters" type="bom:parametersType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Inputs that have the form of parameters with names and values.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="environmentVars" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Inputs that have the form of parameters with names and values.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <!-- maxOccurs="unbounded" NEEDS to be set on the sequence, not the individual elements -->
+                            <xs:choice>
+                                <xs:element name="environmentVar" type="bom:propertyType" minOccurs="0" maxOccurs="1"/>
+                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                            </xs:choice>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="data" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Inputs that have the form of data.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="source" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A references to the component or service that provided the input to the task
+                        (e.g., reference to a service with data flow value of inbound)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="target" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A reference to the component or service that received or stored the input if not the task
+                        itself (e.g., a local, named storage workspace)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="outputType">
+        <xs:annotation>
+            <xs:documentation>
+                Represents resources and data output from a task at runtime by executor or task commands
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="resource" type="bom:resourceReferenceType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to an independent resource generated as output by the task.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="environmentVars" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Outputs that have the form of environment variables.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <!-- maxOccurs="unbounded" NEEDS to be set on the sequence, not the individual elements -->
+                            <xs:choice>
+                                <xs:element name="environmentVar" type="bom:propertyType" minOccurs="0" maxOccurs="1"/>
+                                <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                            </xs:choice>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="data" type="bom:attachedTextType" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Outputs that have the form of data.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="type" type="bom:outputTypeEnum" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Describes the type of data output.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="source" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component or service that generated or provided the output from the task (e.g., a build tool)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="target" type="bom:resourceReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Component or service that received the output from the task
+                        (e.g., reference to an artifactory service with data flow value of outbound)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document properties in a name/value store.
+                        This provides flexibility to include data not officially supported in the standard
+                        without having to use additional namespaces or create extensions. Property names
+                        of interest to the general public are encouraged to be registered in the
+                        CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                        Formal registration is optional.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:simpleType name="outputTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="artifact"/>
+            <xs:enumeration value="attestation"/>
+            <xs:enumeration value="log"/>
+            <xs:enumeration value="evidence"/>
+            <xs:enumeration value="metrics"/>
+            <xs:enumeration value="other"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="parametersType">
+        <xs:sequence>
+            <xs:element name="parameter" type="bom:parameterType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="parameterType">
+        <xs:annotation>
+            <xs:documentation>
+                A representation of a functional parameter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The value of the parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="dataType" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The data type of the parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="cryptoPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Cryptographic assets have properties that uniquely define them and that make them actionable for
+                further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES)
+                or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the
+                algorithm primitive (authenticated encryption) is only defined by the definition of the algorithm variant.
+                The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="assetType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cryptographic assets occur in several forms. Algorithms and protocols are most commonly
+                        implemented in specialized cryptographic libraries. They may however also be 'hardcoded'
+                        in software components. Certificates and related cryptographic material like keys, tokens,
+                        secrets or passwords are other cryptographic assets to be modelled.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="algorithm">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Mathematical function commonly used for data encryption, authentication, and
+                                    digital signatures.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="certificate">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An electronic document that is used to provide the identity or validate a public key.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="protocol">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A set of rules and guidelines that govern the behavior and communication with each other.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="related-crypto-material">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Other cryptographic assets that are related to algorithms, certificate, and protocols
+                                    such as keys and tokens.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="algorithmProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Additional properties specific to a cryptographic algorithm.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="primitive" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Cryptographic building blocks used in higher-level cryptographic systems and
+                                    protocols. Primitives represent different cryptographic routines: deterministic
+                                    random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message
+                                    authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES),
+                                    streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256),
+                                    public-key encryption schemes (pke, e.g. RSA), extended output functions
+                                    (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement
+                                    algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated
+                                    encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms
+                                    (combiner, e.g. SP800-56Cr2).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="drbg">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Deterministic Random Bit Generator (DRBG) is a type of pseudorandom
+                                                number generator designed to produce a sequence of bits from an initial
+                                                seed value. DRBGs are commonly used in cryptographic applications where
+                                                reproducibility of random values is important.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="mac">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                In cryptography, a Message Authentication Code (MAC) is information
+                                                used for authenticating and integrity-checking a message.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="block-cipher">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A block cipher is a symmetric key algorithm that operates on fixed-size
+                                                blocks of data. It encrypts or decrypts the data in block units,
+                                                providing confidentiality. Block ciphers are widely used in various
+                                                cryptographic modes and protocols for secure data transmission.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="stream-cipher">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A stream cipher is a symmetric key cipher where plaintext digits are
+                                                combined with a pseudorandom cipher digit stream (keystream).
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="signature">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                In cryptography, a signature is a digital representation of a message
+                                                or data that proves its origin, identity, and integrity. Digital
+                                                signatures are generated using cryptographic algorithms and are widely
+                                                used for authentication and verification in secure communication.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="hash">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A hash function is a mathematical algorithm that takes an input
+                                                (or 'message') and produces a fixed-size string of characters, which is
+                                                typically a hash value. Hash functions are commonly used in various
+                                                cryptographic applications, including data integrity verification and
+                                                password hashing.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="pke">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Public Key Encryption (PKE) is a type of encryption that uses a pair of
+                                                public and private keys for secure communication. The public key is used
+                                                for encryption, while the private key is used for decryption. PKE is a
+                                                fundamental component of public-key cryptography.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="xof">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                An XOF is an extendable output function that can take arbitrary input
+                                                and creates a stream of output, up to a limit determined by the size of
+                                                the internal state of the hash function that underlies the XOF.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="kdf">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A Key Derivation Function (KDF) derives key material from another source
+                                                of entropy while preserving the entropy of the input.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="key-agree">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                In cryptography, a key-agreement is a protocol whereby two or more
+                                                parties agree on a cryptographic key in such a way that both influence
+                                                the outcome.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="kem">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for
+                                                transporting random keying material to a recipient using the recipient's
+                                                public key.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ae">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Authenticated Encryption (AE) is a cryptographic process that provides
+                                                both confidentiality and data integrity. It ensures that the encrypted
+                                                data has not been tampered with and comes from a legitimate source.
+                                                AE is commonly used in secure communication protocols.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="combiner">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A combiner aggregates many candidates for a cryptographic primitive and
+                                                generates a new candidate for the same primitive.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another primitive type.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The primitive is not known.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="parameterSetIdentifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An identifier for the parameter set of the cryptographic algorithm. Examples: in
+                                    AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the
+                                    digest length, '128' in SHAKE128 identifies its maximum security level in bits, and
+                                    'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="curve" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The specific underlying Elliptic Curve (EC) definition employed which is an indicator
+                                    of the level of security strength, performance and complexity. Absent an
+                                    authoritative source of curve names, CycloneDX recommends use of curve names as
+                                    defined at https://neuromancer.sk/std/, the source from which can be found at
+                                    https://github.com/J08nY/std-curves.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="executionEnvironment" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The target and execution environment in which the algorithm is implemented in.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="software-plain-ram">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A software implementation running in plain unencrypted RAM.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="software-encrypted-ram">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                A software implementation running in encrypted RAM.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration><xs:enumeration value="software-tee">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            A software implementation running in a trusted execution environment.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration><xs:enumeration value="hardware">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            A hardware implementation.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration><xs:enumeration value="other">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Another implementation environment.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration><xs:enumeration value="unknown">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The execution environment is not known.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="implementationPlatform" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The target platform for which the algorithm is implemented. The implementation can
+                                    be 'generic', running on any platform or for a specific platform.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="generic"/>
+                                    <xs:enumeration value="x86_32"/>
+                                    <xs:enumeration value="x86_64"/>
+                                    <xs:enumeration value="armv7-a"/>
+                                    <xs:enumeration value="armv7-m"/>
+                                    <xs:enumeration value="armv8-a"/>
+                                    <xs:enumeration value="armv8-m"/>
+                                    <xs:enumeration value="armv9-a"/>
+                                    <xs:enumeration value="armv9-m"/>
+                                    <xs:enumeration value="s390x"/>
+                                    <xs:enumeration value="ppc64"/>
+                                    <xs:enumeration value="ppc64le"/>
+                                    <xs:enumeration value="other"/>
+                                    <xs:enumeration value="unknown"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="certificationLevel" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The certification that the implementation of the cryptographic algorithm has
+                                    received, if any. Certifications include revisions and levels of FIPS 140 or
+                                    Common Criteria of different Extended Assurance Levels (CC-EAL).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="none">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                No certification obtained
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-1-l4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-1 Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-2-l4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-2 Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="fips140-3-l4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                FIPS 140-3 Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 1
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal1+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 1 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal2">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 2
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal2+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 2 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal3">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 3
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal3+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 3 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal4">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 4
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal4+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 4 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal5">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 5
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal5+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 5 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal6">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 6
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal6+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 6 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal7">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 7
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cc-eal7+">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Common Criteria - Evaluation Assurance Level 7 (Augmented)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another certification
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The certification level is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="mode" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The mode of operation in which the cryptographic algorithm (block cipher) is used.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="cbc">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Cipher block chaining
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ecb">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Electronic codebook
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ccm">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Counter with cipher block chaining message authentication code
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="gcm">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Galois/counter
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="cfb">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Cipher feedback
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ofb">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Output feedback
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ctr">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Counter
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another mode of operation
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The mode of operation is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="padding" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The padding scheme that is used for the cryptographic algorithm.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="pkcs5">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Password-Based Cryptography Specification #5
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="pkcs7">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Public Key Cryptography Standard: Cryptographic Message Syntax
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="pkcs1v15">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Public Key Cryptography Standard: RSA Cryptography v1.5
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="oaep">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Optimal asymmetric encryption padding
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="raw">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Raw
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another padding scheme
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The padding scheme is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="cryptoFunctions" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The cryptographic functions implemented by the cryptographic algorithm.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="cryptoFunction" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="generate"/>
+                                                <xs:enumeration value="keygen"/>
+                                                <xs:enumeration value="encrypt"/>
+                                                <xs:enumeration value="decrypt"/>
+                                                <xs:enumeration value="digest"/>
+                                                <xs:enumeration value="tag"/>
+                                                <xs:enumeration value="keyderive"/>
+                                                <xs:enumeration value="sign"/>
+                                                <xs:enumeration value="verify"/>
+                                                <xs:enumeration value="encapsulate"/>
+                                                <xs:enumeration value="decapsulate"/>
+                                                <xs:enumeration value="other"/>
+                                                <xs:enumeration value="unknown"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="classicalSecurityLevel" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The classical security level that a cryptographic algorithm provides (in bits).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:integer">
+                                    <xs:minInclusive value="0"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="nistQuantumSecurityLevel" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The NIST security strength category as defined in
+                                    https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria).
+                                    A value of 0 indicates that none of the categories are met.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:integer">
+                                    <xs:minInclusive value="0"/>
+                                    <xs:maxInclusive value="6"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="certificateProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties for cryptographic assets of asset type 'certificate'
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="subjectName" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The subject name for the certificate
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="issuerName" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The issuer name for the certificate
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="notValidBefore" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time according to ISO-8601 standard from which the certificate is valid
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="notValidAfter" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time according to ISO-8601 standard from which the certificate is not valid anymore
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="signatureAlgorithmRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The bom-ref to signature algorithm used by the certificate
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="subjectPublicKeyRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The bom-ref to the public key of the subject
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateFormat" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The format of the certificate. Examples include X.509, PEM, DER, and CVC
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="certificateExtension" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The file extension of the certificate. Examples include crt, pem, cer, der, and p12.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="relatedCryptoMaterialProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties for cryptographic assets of asset type 'relatedCryptoMaterial'
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="type" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The type for the related cryptographic material
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="private-key"/>
+                                    <xs:enumeration value="public-key"/>
+                                    <xs:enumeration value="secret-key"/>
+                                    <xs:enumeration value="key"/>
+                                    <xs:enumeration value="ciphertext"/>
+                                    <xs:enumeration value="signature"/>
+                                    <xs:enumeration value="digest"/>
+                                    <xs:enumeration value="initialization-vector"/>
+                                    <xs:enumeration value="nonce"/>
+                                    <xs:enumeration value="seed"/>
+                                    <xs:enumeration value="salt"/>
+                                    <xs:enumeration value="shared-secret"/>
+                                    <xs:enumeration value="tag"/>
+                                    <xs:enumeration value="additional-data"/>
+                                    <xs:enumeration value="password"/>
+                                    <xs:enumeration value="credential"/>
+                                    <xs:enumeration value="token"/>
+                                    <xs:enumeration value="other"/>
+                                    <xs:enumeration value="unknown"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="id" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The optional unique identifier for the related cryptographic material.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="state" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The key state as defined by NIST SP 800-57.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="pre-activation"/>
+                                    <xs:enumeration value="active"/>
+                                    <xs:enumeration value="suspended"/>
+                                    <xs:enumeration value="deactivated"/>
+                                    <xs:enumeration value="compromised"/>
+                                    <xs:enumeration value="destroyed"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="algorithmRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The bom-ref to the algorithm used to generate the related cryptographic material.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="creationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material was created.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="activationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material was activated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="updateDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material was updated.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="expirationDate" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The date and time (timestamp) when the related cryptographic material expires.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The associated value of the cryptographic material.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The size of the cryptographic asset (in bits).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The format of the related cryptographic material (e.g. P8, PEM, DER).
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="securedBy" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The mechanism by which the cryptographic asset is secured by.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="mechanism" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specifies the mechanism by which the cryptographic asset is secured by.
+                                                Examples include HSM, TPM, XGX, Software, and None.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="algorithmRef" type="bom:refType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The bom-ref to the algorithm.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="protocolProperties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties specific to cryptographic assets of type: 'protocol'.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="type" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The concrete protocol type.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="tls">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transport Layer Security
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ssh">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Secure Shell
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ipsec">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Internet Protocol Security
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="ike">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Internet Key Exchange
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="sstp">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Secure Socket Tunneling Protocol
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="wpa">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Wi-Fi Protected Access
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="other">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Another protocol type
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                    <xs:enumeration value="unknown">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The protocol type is not known
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:enumeration>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="version" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The version of the protocol. Examples include 1.0, 1.2, and 1.99.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="cipherSuites" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A list of cipher suites related to the protocol.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="cipherSuite" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A common name for the cipher suite. For example: TLS_DHE_RSA_WITH_AES_128_CCM
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="algorithms" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A list of algorithms related to the cipher suite.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="algorithm" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The bom-ref to algorithm cryptographic asset.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="identifiers" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A list of common identifiers for the cipher suite.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="identifier" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        Cipher suite identifier. Examples include 0xC0 and 0x9E.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ikev2TransformTypes" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The IKEv2 transform types supported (types 1-4), defined in RFC7296 section 3.3.2,
+                                    and additional properties.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="encr" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 1: encryption algorithms
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="prf" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 2: pseudorandom functions
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="integ" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 3: integrity algorithms
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="ke" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Transform Type 4: Key Exchange Method (KE) per RFC9370, formerly called Diffie-Hellman Group (D-H)
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="esn" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specifies if an Extended Sequence Number (ESN) is used.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="auth" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                IKEv2 Authentication method
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="cryptoRef" type="bom:refType" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>A protocol-related cryptographic assets</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="oid" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The object identifier (OID) of the cryptographic asset.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="declarationsType">
+        <xs:sequence>
+            <xs:element name="assessors" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="assessor" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="thirdParty" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The entity issuing the assessment.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An optional identifier which can be used to reference the object elsewhere in the BOM.
+                                            Every bom-ref must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="attestations" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of attestations asserted by an assessor that maps requirements to claims.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="attestation" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An attestation asserted by an assessor that maps requirements to claims.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="summary" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The short description explaining the main points of the attestation.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="assessor" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The `bom-ref` to the assessor asserting the attestation.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="map" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The grouping of requirements to claims and the attestors declared conformance and confidence thereof.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="requirement" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The `bom-ref` to the requirement being attested to.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="claims" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The list of `bom-ref` to the claims being attested to.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="claim" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The `bom-ref` to the claim being attested to.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="counterClaims" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The list of `bom-ref` to the counter claims being attested to.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="counterClaim" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The `bom-ref` to the counter claim being attested to.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="conformance" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The conformance of the claim meeting a requirement.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="score">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:decimal">
+                                                                        <xs:minInclusive value="0"/>
+                                                                        <xs:maxInclusive value="1"/>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="rationale" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The rationale for the score of conformance.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="mitigationStrategies" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The list of  `bom-ref` to the evidence provided describing the
+                                                                        mitigation strategies. Each mitigation strategy should include an
+                                                                        explanation of how any weaknesses in the evidence will be mitigated.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:complexType>
+                                                                    <xs:sequence>
+                                                                        <xs:element name="mitigationStrategy" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded"/>
+                                                                    </xs:sequence>
+                                                                </xs:complexType>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="confidence" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The confidence of the claim meeting the requirement.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="score">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:simpleType>
+                                                                    <xs:restriction base="xs:decimal">
+                                                                        <xs:minInclusive value="0"/>
+                                                                        <xs:maxInclusive value="1"/>
+                                                                    </xs:restriction>
+                                                                </xs:simpleType>
+                                                            </xs:element>
+                                                            <xs:element name="rationale" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>
+                                                                        The rationale for the confidence score.
+                                                                    </xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:any>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="claims" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of claims.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="claim" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="target" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The `bom-ref` to a target representing a specific system, application,
+                                                API, module, team, person, process, business unit, company, etc...
+                                                that this claim is being applied to.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="predicate" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The specific statement or assertion about the target.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="mitigationStrategies" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of  `bom-ref` to the evidence provided describing the
+                                                mitigation strategies. Each mitigation strategy should include an
+                                                explanation of how any weaknesses in the evidence will be mitigated.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="mitigationStrategy" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="reasoning" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The written explanation of why the evidence provided substantiates the claim.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="evidence" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of `bom-ref` to evidence that supports this claim.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="counterEvidence" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of `bom-ref` to counterEvidence that supports this claim.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document external references related to the claim the BOM describes.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:any>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An optional identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="evidence" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of evidence
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="evidence" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of evidence
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="propertyName" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/).
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The written description of what this evidence is and how it was created.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="data" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The output or analysis that supports claims.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The name of the data.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="contents" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The contents or references to the contents of the data being described.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="attachment" type="bom:attachedTextType" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>An optional way to include textual or encoded data.</xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                            <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+                                                                <xs:annotation>
+                                                                    <xs:documentation>The URL to where the data can be retrieved.</xs:documentation>
+                                                                </xs:annotation>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="classification" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="sensitiveData" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            A description of any sensitive data.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="governance" type="bom:dataGovernance" minOccurs="0" maxOccurs="1" />
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="created" type="xs:dateTime" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>The date and time (timestamp) when the evidence was created.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="expires" type="xs:dateTime" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>The optional date and time (timestamp) when the evidence is no longer valid.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="author" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The author of the evidence.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="reviewer" type="bom:organizationalContact" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>The reviewer of the evidence.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:any>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An optional identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="targets" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of targets which claims are made against.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="organizations" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of organizations which claims are made against.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="components" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of components which claims are made against.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="component" type="bom:component" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="services" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of services which claims are made against.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="service" type="bom:service" minOccurs="0" maxOccurs="unbounded" />
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="affirmation" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment.
+                        It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="statement" type="xs:string" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The brief statement affirmed by an individual regarding all declarations.
+                                    This could be an affirmation of acceptance by a third-party auditor or receiving
+                                    individual of a file. For example: "I certify, to the best of my knowledge, that all information is correct."
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="signatories" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The list of signatories authorized on behalf of an organization to assert validity of this document.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="signatory" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The signatory's name.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="role" type="xs:string" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The signatory's role within an organization.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="organization" type="bom:organizationalEntity" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The signatory's organization.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:element name="externalReference" type="bom:externalReference" minOccurs="0" maxOccurs="1">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            An External reference provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:element>
+                                                <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:any>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Allows any undeclared elements as long as the elements are placed in a different namespace.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:any>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="definitionsType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of reusable objects that are defined and may be used elsewhere in the BOM.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="standards" type="bom:standardsType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="standardsType">
+        <xs:annotation>
+            <xs:documentation>
+                The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="standard" type="bom:standard"/>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##any" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="standard">
+        <xs:annotation>
+            <xs:documentation>
+                A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="name" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the standard. This will often be a shortened, single name of the standard.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The version of the standard.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The description of the standard.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="owner" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The owner of the standard, often the entity responsible for its release.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="requirements" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of requirements comprising the standard.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="requirement" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="identifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The title of the requirement.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="text" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The textual content of the requirement.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="descriptions" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="openCre" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:pattern value="CRE:[0-9]+-[0-9]+"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="parent" type="bom:refLinkType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The optional `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document properties in a name/value store.
+                                                This provides flexibility to include data not officially supported in the standard
+                                                without having to use additional namespaces or create extensions. Property names
+                                                of interest to the general public are encouraged to be registered in the
+                                                CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                                                Formal registration is optional.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>Provides the ability to document external references related to the BOM or
+                                                to the project the BOM describes.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An optional identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="levels" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The list of levels associated with the standard. Some standards have different levels of compliance.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="level" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="identifier" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The identifier used in the standard to identify a specific level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The title of the level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The description of the level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="requirements" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The list of requirement `bom-ref`s that comprise the level.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="requirement" type="bom:refLinkType" minOccurs="0" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="bom-ref" type="bom:refType">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            An optional identifier which can be used to reference the object elsewhere
+                                            in the BOM. Every bom-ref must be unique within the BOM.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:anyAttribute namespace="##other" processContents="lax">
+                                    <xs:annotation>
+                                        <xs:documentation>User-defined attributes may be used on this element as long as they
+                                            do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:anyAttribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Provides the ability to document external references related to the BOM or
+                        to the project the BOM describes.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows any undeclared elements as long as the elements are placed in a different namespace.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="bom-ref" type="bom:refType">
+            <xs:annotation>
+                <xs:documentation>
+                    An optional identifier which can be used to reference the object elsewhere
+                    in the BOM. Every bom-ref must be unique within the BOM.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax">
+            <xs:annotation>
+                <xs:documentation>User-defined attributes may be used on this element as long as they
+                    do not have the same name as an existing attribute used by the schema.</xs:documentation>
+            </xs:annotation>
+        </xs:anyAttribute>
+    </xs:complexType>
+
+    <xs:complexType name="tagsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="tag" type="xs:normalizedString">
+                <xs:annotation>
+                    <xs:documentation>Textual strings that aid in discovery, search, and retrieval of the associated
+                        object. Tags often serve as a way to group or categorize similar or related objects by various
+                        attributes.
+
+                        Examples include:
+                        "json-parser", "object-persistence", "text-to-image", "translation", and "object-detection"
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="bom">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="metadata" type="bom:metadata" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides additional information about a BOM.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="components" type="bom:componentsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A list of software and hardware components.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="services" type="bom:servicesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>A list of services. This may include microservices, function-as-a-service, and other types of network or intra-process services.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="externalReferences" type="bom:externalReferences" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document external references related to the BOM or
+                            to the project the BOM describes.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dependencies" type="bom:dependenciesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document dependency relationships.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="compositions" type="bom:compositionsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="properties" type="bom:propertiesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Provides the ability to document properties in a name/value store.
+                            This provides flexibility to include data not officially supported in the standard
+                            without having to use additional namespaces or create extensions. Property names
+                            of interest to the general public are encouraged to be registered in the
+                            CycloneDX Property Taxonomy - https://github.com/CycloneDX/cyclonedx-property-taxonomy.
+                            Formal registration is optional.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="vulnerabilities" type="bom:vulnerabilitiesType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Vulnerabilities identified in components or services.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="annotations" type="bom:annotationsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Comments made by people, organizations, or tools about any object with
+                            a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike
+                            inventory information, annotations may contain opinion or commentary from various
+                            stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link,
+                            and may optionally be signed.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="formulation" type="bom:formulationType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Describes how a component or service was manufactured or deployed. This is
+                            achieved through the use of formulas, workflows, tasks, and steps, which declare the precise
+                            steps to reproduce along with the observed formulas describing the steps which transpired
+                            in the manufacturing process.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="declarations" type="bom:declarationsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The list of declarations which describe the conformance to standards. Each declaration may
+                            include attestations, claims, and evidence.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="definitions" type="bom:definitionsType" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A collection of reusable objects that are defined and may be used elsewhere in the BOM.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Allows any undeclared elements as long as the elements are placed in a different namespace.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:positiveInteger" default="1">
+                <xs:annotation>
+                    <xs:documentation>Whenever an existing BOM is modified, either manually or through automated
+                        processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with
+                        multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM.
+                        The default version is '1'.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="serialNumber" type="bom:urnUuid">
+                <xs:annotation>
+                    <xs:documentation>Every BOM generated SHOULD have a unique serial number, even if the contents of
+                        the BOM have not changed over time. If specified, the serial number must conform to RFC-4122.
+                        Use of serial numbers are recommended.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:anyAttribute namespace="##any" processContents="lax">
+                <xs:annotation>
+                    <xs:documentation>User-defined attributes may be used on this element as long as they
+                        do not have the same name as an existing attribute used by the schema.</xs:documentation>
+                </xs:annotation>
+            </xs:anyAttribute>
+        </xs:complexType>
+        <xs:unique name="bom-ref">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@bom-ref"/>
+        </xs:unique>
+    </xs:element>
+</xs:schema>

--- a/src/sbom_validator/schemas/cyclonedx-spdx.xsd
+++ b/src/sbom_validator/schemas/cyclonedx-spdx.xsd
@@ -1,0 +1,4069 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://cyclonedx.org/schema/spdx"
+           version="1.0-3.28.0">
+
+    <xs:simpleType name="licenseId">
+        <xs:restriction base="xs:string">
+            <!-- Licenses -->
+            <xs:enumeration value="0BSD">
+                <xs:annotation>
+                    <xs:documentation>BSD Zero Clause License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3D-Slicer-1.0">
+                <xs:annotation>
+                    <xs:documentation>3D Slicer License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AAL">
+                <xs:annotation>
+                    <xs:documentation>Attribution Assurance License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Abstyles">
+                <xs:annotation>
+                    <xs:documentation>Abstyles License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AdaCore-doc">
+                <xs:annotation>
+                    <xs:documentation>AdaCore Doc License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Adobe-2006">
+                <xs:annotation>
+                    <xs:documentation>Adobe Systems Incorporated Source Code License Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Adobe-Display-PostScript">
+                <xs:annotation>
+                    <xs:documentation>Adobe Display PostScript License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Adobe-Glyph">
+                <xs:annotation>
+                    <xs:documentation>Adobe Glyph List License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Adobe-Utopia">
+                <xs:annotation>
+                    <xs:documentation>Adobe Utopia Font License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ADSL">
+                <xs:annotation>
+                    <xs:documentation>Amazon Digital Services License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Advanced-Cryptics-Dictionary">
+                <xs:annotation>
+                    <xs:documentation>Advanced Cryptics Dictionary License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AFL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Academic Free License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AFL-1.2">
+                <xs:annotation>
+                    <xs:documentation>Academic Free License v1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AFL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Academic Free License v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AFL-2.1">
+                <xs:annotation>
+                    <xs:documentation>Academic Free License v2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AFL-3.0">
+                <xs:annotation>
+                    <xs:documentation>Academic Free License v3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Afmparse">
+                <xs:annotation>
+                    <xs:documentation>Afmparse License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AGPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Affero General Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AGPL-1.0-only">
+                <xs:annotation>
+                    <xs:documentation>Affero General Public License v1.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AGPL-1.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>Affero General Public License v1.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AGPL-3.0">
+                <xs:annotation>
+                    <xs:documentation>GNU Affero General Public License v3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AGPL-3.0-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Affero General Public License v3.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AGPL-3.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Affero General Public License v3.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Aladdin">
+                <xs:annotation>
+                    <xs:documentation>Aladdin Free Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ALGLIB-Documentation">
+                <xs:annotation>
+                    <xs:documentation>ALGLIB Documentation License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMD-newlib">
+                <xs:annotation>
+                    <xs:documentation>AMD newlib License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMDPLPA">
+                <xs:annotation>
+                    <xs:documentation>AMD&apos;s plpa_map.c License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AML">
+                <xs:annotation>
+                    <xs:documentation>Apple MIT License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AML-glslang">
+                <xs:annotation>
+                    <xs:documentation>AML glslang variant License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="AMPAS">
+                <xs:annotation>
+                    <xs:documentation>Academy of Motion Picture Arts and Sciences BSD</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ANTLR-PD">
+                <xs:annotation>
+                    <xs:documentation>ANTLR Software Rights Notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ANTLR-PD-fallback">
+                <xs:annotation>
+                    <xs:documentation>ANTLR Software Rights Notice with license fallback</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="any-OSI">
+                <xs:annotation>
+                    <xs:documentation>Any OSI License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="any-OSI-perl-modules">
+                <xs:annotation>
+                    <xs:documentation>Any OSI License - Perl Modules</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Apache-1.0">
+                <xs:annotation>
+                    <xs:documentation>Apache License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Apache-1.1">
+                <xs:annotation>
+                    <xs:documentation>Apache License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Apache-2.0">
+                <xs:annotation>
+                    <xs:documentation>Apache License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="APAFML">
+                <xs:annotation>
+                    <xs:documentation>Adobe Postscript AFM License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="APL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Adaptive Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="App-s2p">
+                <xs:annotation>
+                    <xs:documentation>App::s2p License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="APSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Apple Public Source License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="APSL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Apple Public Source License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="APSL-1.2">
+                <xs:annotation>
+                    <xs:documentation>Apple Public Source License 1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="APSL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Apple Public Source License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Arphic-1999">
+                <xs:annotation>
+                    <xs:documentation>Arphic Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Artistic-1.0">
+                <xs:annotation>
+                    <xs:documentation>Artistic License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Artistic-1.0-cl8">
+                <xs:annotation>
+                    <xs:documentation>Artistic License 1.0 w/clause 8</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Artistic-1.0-Perl">
+                <xs:annotation>
+                    <xs:documentation>Artistic License 1.0 (Perl)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Artistic-2.0">
+                <xs:annotation>
+                    <xs:documentation>Artistic License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Artistic-dist">
+                <xs:annotation>
+                    <xs:documentation>Artistic License 1.0 (dist)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Aspell-RU">
+                <xs:annotation>
+                    <xs:documentation>Aspell Russian License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ASWF-Digital-Assets-1.0">
+                <xs:annotation>
+                    <xs:documentation>ASWF Digital Assets License version 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ASWF-Digital-Assets-1.1">
+                <xs:annotation>
+                    <xs:documentation>ASWF Digital Assets License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Baekmuk">
+                <xs:annotation>
+                    <xs:documentation>Baekmuk License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Bahyph">
+                <xs:annotation>
+                    <xs:documentation>Bahyph License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Barr">
+                <xs:annotation>
+                    <xs:documentation>Barr License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bcrypt-Solar-Designer">
+                <xs:annotation>
+                    <xs:documentation>bcrypt Solar Designer License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Beerware">
+                <xs:annotation>
+                    <xs:documentation>Beerware License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Bitstream-Charter">
+                <xs:annotation>
+                    <xs:documentation>Bitstream Charter Font License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Bitstream-Vera">
+                <xs:annotation>
+                    <xs:documentation>Bitstream Vera Font License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BitTorrent-1.0">
+                <xs:annotation>
+                    <xs:documentation>BitTorrent Open Source License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BitTorrent-1.1">
+                <xs:annotation>
+                    <xs:documentation>BitTorrent Open Source License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="blessing">
+                <xs:annotation>
+                    <xs:documentation>SQLite Blessing</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BlueOak-1.0.0">
+                <xs:annotation>
+                    <xs:documentation>Blue Oak Model License 1.0.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Boehm-GC">
+                <xs:annotation>
+                    <xs:documentation>Boehm-Demers-Weiser GC License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Boehm-GC-without-fee">
+                <xs:annotation>
+                    <xs:documentation>Boehm-Demers-Weiser GC License (without fee)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BOLA-1.1">
+                <xs:annotation>
+                    <xs:documentation>Buena Onda License Agreement v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Borceux">
+                <xs:annotation>
+                    <xs:documentation>Borceux license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Brian-Gladman-2-Clause">
+                <xs:annotation>
+                    <xs:documentation>Brian Gladman 2-Clause License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Brian-Gladman-3-Clause">
+                <xs:annotation>
+                    <xs:documentation>Brian Gladman 3-Clause License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-1-Clause">
+                <xs:annotation>
+                    <xs:documentation>BSD 1-Clause License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause &quot;Simplified&quot; License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-Darwin">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause - Ian Darwin variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-first-lines">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause - first lines requirement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-FreeBSD">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause FreeBSD License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-NetBSD">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause NetBSD License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-Patent">
+                <xs:annotation>
+                    <xs:documentation>BSD-2-Clause Plus Patent License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-pkgconf-disclaimer">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause pkgconf disclaimer variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-2-Clause-Views">
+                <xs:annotation>
+                    <xs:documentation>BSD 2-Clause with views sentence</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-acpica">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause acpica variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-Attribution">
+                <xs:annotation>
+                    <xs:documentation>BSD with attribution</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-Clear">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause Clear License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-flex">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause Flex variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-HP">
+                <xs:annotation>
+                    <xs:documentation>Hewlett-Packard BSD variant license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-LBNL">
+                <xs:annotation>
+                    <xs:documentation>Lawrence Berkeley National Labs BSD variant license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-Modification">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause Modification</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-No-Military-License">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause No Military License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-No-Nuclear-License">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause No Nuclear License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-No-Nuclear-License-2014">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause No Nuclear License 2014</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-No-Nuclear-Warranty">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause No Nuclear Warranty</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-Open-MPI">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause Open MPI variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-Sun">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause Sun Microsystems</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-3-Clause-Tso">
+                <xs:annotation>
+                    <xs:documentation>BSD 3-Clause Tso variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-4-Clause">
+                <xs:annotation>
+                    <xs:documentation>BSD 4-Clause &quot;Original&quot; or &quot;Old&quot; License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-4-Clause-Shortened">
+                <xs:annotation>
+                    <xs:documentation>BSD 4 Clause Shortened</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-4-Clause-UC">
+                <xs:annotation>
+                    <xs:documentation>BSD-4-Clause (University of California-Specific)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-4.3RENO">
+                <xs:annotation>
+                    <xs:documentation>BSD 4.3 RENO License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-4.3TAHOE">
+                <xs:annotation>
+                    <xs:documentation>BSD 4.3 TAHOE License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Advertising-Acknowledgement">
+                <xs:annotation>
+                    <xs:documentation>BSD Advertising Acknowledgement License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Attribution-HPND-disclaimer">
+                <xs:annotation>
+                    <xs:documentation>BSD with Attribution and HPND disclaimer</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Inferno-Nettverk">
+                <xs:annotation>
+                    <xs:documentation>BSD-Inferno-Nettverk</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Mark-Modifications">
+                <xs:annotation>
+                    <xs:documentation>BSD Mark Modifications License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Protection">
+                <xs:annotation>
+                    <xs:documentation>BSD Protection License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Source-beginning-file">
+                <xs:annotation>
+                    <xs:documentation>BSD Source Code Attribution - beginning of file variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Source-Code">
+                <xs:annotation>
+                    <xs:documentation>BSD Source Code Attribution</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Systemics">
+                <xs:annotation>
+                    <xs:documentation>Systemics BSD variant license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSD-Systemics-W3Works">
+                <xs:annotation>
+                    <xs:documentation>Systemics W3Works BSD variant license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Boost Software License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Buddy">
+                <xs:annotation>
+                    <xs:documentation>Buddy License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="BUSL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Business Source License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bzip2-1.0.5">
+                <xs:annotation>
+                    <xs:documentation>bzip2 and libbzip2 License v1.0.5</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="bzip2-1.0.6">
+                <xs:annotation>
+                    <xs:documentation>bzip2 and libbzip2 License v1.0.6</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="C-UDA-1.0">
+                <xs:annotation>
+                    <xs:documentation>Computational Use of Data Agreement v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CAL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Cryptographic Autonomy License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CAL-1.0-Combined-Work-Exception">
+                <xs:annotation>
+                    <xs:documentation>Cryptographic Autonomy License 1.0 (Combined Work Exception)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Caldera">
+                <xs:annotation>
+                    <xs:documentation>Caldera License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Caldera-no-preamble">
+                <xs:annotation>
+                    <xs:documentation>Caldera License (without preamble)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CAPEC-tou">
+                <xs:annotation>
+                    <xs:documentation>Common Attack    Pattern Enumeration and Classification License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Catharon">
+                <xs:annotation>
+                    <xs:documentation>Catharon License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CATOSL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Computer Associates Trusted Open Source License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-2.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 2.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-2.5">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 2.5 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-2.5-AU">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 2.5 Australia</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 Unported</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0-AT">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 Austria</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0-AU">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 Australia</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0-IGO">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 IGO</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0-NL">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 Netherlands</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0-US">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 3.0 United States</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-4.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution 4.0 International</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-2.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial 2.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-2.5">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial 2.5 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-3.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial 3.0 Unported</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-3.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial 3.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-4.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial 4.0 International</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-2.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-2.5">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-3.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-3.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-3.0-IGO">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-ND-4.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial No Derivatives 4.0 International</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-2.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 2.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-2.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 2.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-2.0-FR">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-2.0-UK">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-2.5">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 2.5 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-3.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 3.0 Unported</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-3.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 3.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-3.0-IGO">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 3.0 IGO</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-NC-SA-4.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Non Commercial Share Alike 4.0 International</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-ND-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution No Derivatives 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-ND-2.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution No Derivatives 2.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-ND-2.5">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution No Derivatives 2.5 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-ND-3.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution No Derivatives 3.0 Unported</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-ND-3.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution No Derivatives 3.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-ND-4.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution No Derivatives 4.0 International</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-2.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 2.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-2.0-UK">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 2.0 England and Wales</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-2.1-JP">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 2.1 Japan</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-2.5">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 2.5 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-3.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 3.0 Unported</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-3.0-AT">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 3.0 Austria</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-3.0-DE">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 3.0 Germany</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-3.0-IGO">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution-ShareAlike 3.0 IGO</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-BY-SA-4.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Attribution Share Alike 4.0 International</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-PDDC">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Public Domain Dedication and Certification</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-PDM-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative    Commons Public Domain Mark 1.0 Universal</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC-SA-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Share Alike 1.0 Generic</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CC0-1.0">
+                <xs:annotation>
+                    <xs:documentation>Creative Commons Zero v1.0 Universal</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CDDL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Common Development and Distribution License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CDDL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Common Development and Distribution License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CDL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Common Documentation License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CDLA-Permissive-1.0">
+                <xs:annotation>
+                    <xs:documentation>Community Data License Agreement Permissive 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CDLA-Permissive-2.0">
+                <xs:annotation>
+                    <xs:documentation>Community Data License Agreement Permissive 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CDLA-Sharing-1.0">
+                <xs:annotation>
+                    <xs:documentation>Community Data License Agreement Sharing 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CECILL-1.0">
+                <xs:annotation>
+                    <xs:documentation>CeCILL Free Software License Agreement v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CECILL-1.1">
+                <xs:annotation>
+                    <xs:documentation>CeCILL Free Software License Agreement v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CECILL-2.0">
+                <xs:annotation>
+                    <xs:documentation>CeCILL Free Software License Agreement v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CECILL-2.1">
+                <xs:annotation>
+                    <xs:documentation>CeCILL Free Software License Agreement v2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CECILL-B">
+                <xs:annotation>
+                    <xs:documentation>CeCILL-B Free Software License Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CECILL-C">
+                <xs:annotation>
+                    <xs:documentation>CeCILL-C Free Software License Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CERN-OHL-1.1">
+                <xs:annotation>
+                    <xs:documentation>CERN Open Hardware Licence v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CERN-OHL-1.2">
+                <xs:annotation>
+                    <xs:documentation>CERN Open Hardware Licence v1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CERN-OHL-P-2.0">
+                <xs:annotation>
+                    <xs:documentation>CERN Open Hardware Licence Version 2 - Permissive</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CERN-OHL-S-2.0">
+                <xs:annotation>
+                    <xs:documentation>CERN Open Hardware Licence Version 2 - Strongly Reciprocal</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CERN-OHL-W-2.0">
+                <xs:annotation>
+                    <xs:documentation>CERN Open Hardware Licence Version 2 - Weakly Reciprocal</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CFITSIO">
+                <xs:annotation>
+                    <xs:documentation>CFITSIO License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="check-cvs">
+                <xs:annotation>
+                    <xs:documentation>check-cvs License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="checkmk">
+                <xs:annotation>
+                    <xs:documentation>Checkmk License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ClArtistic">
+                <xs:annotation>
+                    <xs:documentation>Clarified Artistic License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Clips">
+                <xs:annotation>
+                    <xs:documentation>Clips License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CMU-Mach">
+                <xs:annotation>
+                    <xs:documentation>CMU Mach License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CMU-Mach-nodoc">
+                <xs:annotation>
+                    <xs:documentation>CMU    Mach - no notices-in-documentation variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CNRI-Jython">
+                <xs:annotation>
+                    <xs:documentation>CNRI Jython License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CNRI-Python">
+                <xs:annotation>
+                    <xs:documentation>CNRI Python License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CNRI-Python-GPL-Compatible">
+                <xs:annotation>
+                    <xs:documentation>CNRI Python Open Source GPL Compatible License Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="COIL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Copyfree Open Innovation License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Community-Spec-1.0">
+                <xs:annotation>
+                    <xs:documentation>Community Specification License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Condor-1.1">
+                <xs:annotation>
+                    <xs:documentation>Condor Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="copyleft-next-0.3.0">
+                <xs:annotation>
+                    <xs:documentation>copyleft-next 0.3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="copyleft-next-0.3.1">
+                <xs:annotation>
+                    <xs:documentation>copyleft-next 0.3.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Cornell-Lossless-JPEG">
+                <xs:annotation>
+                    <xs:documentation>Cornell Lossless JPEG License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CPAL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Common Public Attribution License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Common Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CPOL-1.02">
+                <xs:annotation>
+                    <xs:documentation>Code Project Open License 1.02</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Cronyx">
+                <xs:annotation>
+                    <xs:documentation>Cronyx License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Crossword">
+                <xs:annotation>
+                    <xs:documentation>Crossword License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CryptoSwift">
+                <xs:annotation>
+                    <xs:documentation>CryptoSwift License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CrystalStacker">
+                <xs:annotation>
+                    <xs:documentation>CrystalStacker License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CUA-OPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>CUA Office Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Cube">
+                <xs:annotation>
+                    <xs:documentation>Cube License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="curl">
+                <xs:annotation>
+                    <xs:documentation>curl License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cve-tou">
+                <xs:annotation>
+                    <xs:documentation>Common Vulnerability Enumeration ToU License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="D-FSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Deutsche Freie Software Lizenz</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DEC-3-Clause">
+                <xs:annotation>
+                    <xs:documentation>DEC 3-Clause License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="diffmark">
+                <xs:annotation>
+                    <xs:documentation>diffmark license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DL-DE-BY-2.0">
+                <xs:annotation>
+                    <xs:documentation>Data licence Germany – attribution – version 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DL-DE-ZERO-2.0">
+                <xs:annotation>
+                    <xs:documentation>Data licence Germany – zero – version 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DOC">
+                <xs:annotation>
+                    <xs:documentation>DOC License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DocBook-DTD">
+                <xs:annotation>
+                    <xs:documentation>DocBook DTD License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DocBook-Schema">
+                <xs:annotation>
+                    <xs:documentation>DocBook Schema License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DocBook-Stylesheet">
+                <xs:annotation>
+                    <xs:documentation>DocBook Stylesheet License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DocBook-XML">
+                <xs:annotation>
+                    <xs:documentation>DocBook XML License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Dotseqn">
+                <xs:annotation>
+                    <xs:documentation>Dotseqn License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DRL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Detection Rule License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DRL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Detection Rule License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DSDP">
+                <xs:annotation>
+                    <xs:documentation>DSDP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dtoa">
+                <xs:annotation>
+                    <xs:documentation>David M. Gay dtoa License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dvipdfm">
+                <xs:annotation>
+                    <xs:documentation>dvipdfm License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ECL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Educational Community License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ECL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Educational Community License v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="eCos-2.0">
+                <xs:annotation>
+                    <xs:documentation>eCos license version 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EFL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Eiffel Forum License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EFL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Eiffel Forum License v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="eGenix">
+                <xs:annotation>
+                    <xs:documentation>eGenix.com Public License 1.1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Elastic-2.0">
+                <xs:annotation>
+                    <xs:documentation>Elastic License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Entessa">
+                <xs:annotation>
+                    <xs:documentation>Entessa Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EPICS">
+                <xs:annotation>
+                    <xs:documentation>EPICS Open License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Eclipse Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EPL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Eclipse Public License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ErlPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Erlang Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ESA-PL-permissive-2.4">
+                <xs:annotation>
+                    <xs:documentation>European Space Agency Public License – v2.4 – Permissive (Type 3)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ESA-PL-strong-copyleft-2.4">
+                <xs:annotation>
+                    <xs:documentation>European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ESA-PL-weak-copyleft-2.4">
+                <xs:annotation>
+                    <xs:documentation>European Space Agency Public License – v2.4 – Weak Copyleft (Type 2)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="etalab-2.0">
+                <xs:annotation>
+                    <xs:documentation>Etalab Open License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EUDatagrid">
+                <xs:annotation>
+                    <xs:documentation>EU DataGrid Software License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EUPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>European Union Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EUPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>European Union Public License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="EUPL-1.2">
+                <xs:annotation>
+                    <xs:documentation>European Union Public License 1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Eurosym">
+                <xs:annotation>
+                    <xs:documentation>Eurosym License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Fair">
+                <xs:annotation>
+                    <xs:documentation>Fair License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FBM">
+                <xs:annotation>
+                    <xs:documentation>Fuzzy Bitmap License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FDK-AAC">
+                <xs:annotation>
+                    <xs:documentation>Fraunhofer FDK AAC Codec Library</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ferguson-Twofish">
+                <xs:annotation>
+                    <xs:documentation>Ferguson Twofish License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Frameworx-1.0">
+                <xs:annotation>
+                    <xs:documentation>Frameworx Open License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FreeBSD-DOC">
+                <xs:annotation>
+                    <xs:documentation>FreeBSD Documentation License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FreeImage">
+                <xs:annotation>
+                    <xs:documentation>FreeImage Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSFAP">
+                <xs:annotation>
+                    <xs:documentation>FSF All Permissive License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSFAP-no-warranty-disclaimer">
+                <xs:annotation>
+                    <xs:documentation>FSF All Permissive License (without Warranty)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSFUL">
+                <xs:annotation>
+                    <xs:documentation>FSF Unlimited License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSFULLR">
+                <xs:annotation>
+                    <xs:documentation>FSF Unlimited License (with License Retention)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSFULLRSD">
+                <xs:annotation>
+                    <xs:documentation>FSF Unlimited License (with License Retention and Short Disclaimer)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSFULLRWD">
+                <xs:annotation>
+                    <xs:documentation>FSF Unlimited License (With License Retention and Warranty Disclaimer)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSL-1.1-ALv2">
+                <xs:annotation>
+                    <xs:documentation>Functional Source License, Version 1.1, ALv2 Future License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FSL-1.1-MIT">
+                <xs:annotation>
+                    <xs:documentation>Functional Source License, Version 1.1, MIT Future License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FTL">
+                <xs:annotation>
+                    <xs:documentation>Freetype Project License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Furuseth">
+                <xs:annotation>
+                    <xs:documentation>Furuseth License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="fwlw">
+                <xs:annotation>
+                    <xs:documentation>fwlw License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Game-Programming-Gems">
+                <xs:annotation>
+                    <xs:documentation>Game Programming Gems License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GCR-docs">
+                <xs:annotation>
+                    <xs:documentation>Gnome GCR Documentation License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GD">
+                <xs:annotation>
+                    <xs:documentation>GD License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="generic-xts">
+                <xs:annotation>
+                    <xs:documentation>Generic XTS License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1-invariants-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1 only - invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1-invariants-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1 or later - invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1-no-invariants-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1 only - no invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1-no-invariants-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1 or later - no invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.1-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.1 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2-invariants-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2 only - invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2-invariants-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2 or later - invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2-no-invariants-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2 only - no invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2-no-invariants-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2 or later - no invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.2-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.2 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3-invariants-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3 only - invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3-invariants-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3 or later - invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3-no-invariants-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3 only - no invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3-no-invariants-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3 or later - no invariants</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GFDL-1.3-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Free Documentation License v1.3 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Giftware">
+                <xs:annotation>
+                    <xs:documentation>Giftware License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GL2PS">
+                <xs:annotation>
+                    <xs:documentation>GL2PS License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Glide">
+                <xs:annotation>
+                    <xs:documentation>3dfx Glide License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Glulxe">
+                <xs:annotation>
+                    <xs:documentation>Glulxe License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GLWTPL">
+                <xs:annotation>
+                    <xs:documentation>Good Luck With That Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="gnuplot">
+                <xs:annotation>
+                    <xs:documentation>gnuplot License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v1.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-1.0+">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v1.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-1.0-only">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v1.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-1.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v1.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0+">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-only">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-with-autoconf-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 w/Autoconf exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-with-bison-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 w/Bison exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-with-classpath-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 w/Classpath exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-with-font-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 w/Font exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-2.0-with-GCC-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v2.0 w/GCC Runtime Library exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v3.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0+">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v3.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-only">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v3.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v3.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-with-autoconf-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v3.0 w/Autoconf exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-with-GCC-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU General Public License v3.0 w/GCC Runtime Library exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Graphics-Gems">
+                <xs:annotation>
+                    <xs:documentation>Graphics Gems License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="gSOAP-1.3b">
+                <xs:annotation>
+                    <xs:documentation>gSOAP Public License v1.3b</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="gtkbook">
+                <xs:annotation>
+                    <xs:documentation>gtkbook License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Gutmann">
+                <xs:annotation>
+                    <xs:documentation>Gutmann License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HaskellReport">
+                <xs:annotation>
+                    <xs:documentation>Haskell Language Report License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HDF5">
+                <xs:annotation>
+                    <xs:documentation>HDF5 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="hdparm">
+                <xs:annotation>
+                    <xs:documentation>hdparm License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HIDAPI">
+                <xs:annotation>
+                    <xs:documentation>HIDAPI License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Hippocratic-2.1">
+                <xs:annotation>
+                    <xs:documentation>Hippocratic License 2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HP-1986">
+                <xs:annotation>
+                    <xs:documentation>Hewlett-Packard 1986 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HP-1989">
+                <xs:annotation>
+                    <xs:documentation>Hewlett-Packard 1989 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-DEC">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - DEC variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-doc">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - documentation variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-doc-sell">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - documentation sell variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-export-US">
+                <xs:annotation>
+                    <xs:documentation>HPND with US Government export control warning</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-export-US-acknowledgement">
+                <xs:annotation>
+                    <xs:documentation>HPND with US Government export control warning and acknowledgment</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-export-US-modify">
+                <xs:annotation>
+                    <xs:documentation>HPND with US Government export control warning and modification rqmt</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-export2-US">
+                <xs:annotation>
+                    <xs:documentation>HPND with US Government export control and 2 disclaimers</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-Fenneberg-Livingston">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-INRIA-IMAG">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer    - INRIA-IMAG variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-Intel">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - Intel variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-Kevlin-Henney">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - Kevlin Henney variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-Markus-Kuhn">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - Markus Kuhn variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-merchantability-variant">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - merchantability variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-MIT-disclaimer">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer with MIT disclaimer</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-Netrek">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - Netrek variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-Pbmplus">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - Pbmplus variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-sell-MIT-disclaimer-xserver">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-sell-regexpr">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - sell regexpr variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-sell-variant">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - sell variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-sell-variant-critical-systems">
+                <xs:annotation>
+                    <xs:documentation>HPND - sell variant with safety critical systems clause</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-sell-variant-MIT-disclaimer">
+                <xs:annotation>
+                    <xs:documentation>HPND sell variant with MIT disclaimer</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-sell-variant-MIT-disclaimer-rev">
+                <xs:annotation>
+                    <xs:documentation>HPND sell variant with MIT disclaimer - reverse</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-SMC">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - SMC variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-UC">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - University of California variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HPND-UC-export-US">
+                <xs:annotation>
+                    <xs:documentation>Historical Permission Notice and Disclaimer - University of California, US export warning</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HTMLTIDY">
+                <xs:annotation>
+                    <xs:documentation>HTML Tidy License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="hyphen-bulgarian">
+                <xs:annotation>
+                    <xs:documentation>hyphen-bulgarian License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="IBM-pibs">
+                <xs:annotation>
+                    <xs:documentation>IBM PowerPC Initialization and Boot Software</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ICU">
+                <xs:annotation>
+                    <xs:documentation>ICU License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="IEC-Code-Components-EULA">
+                <xs:annotation>
+                    <xs:documentation>IEC    Code Components End-user licence agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="IJG">
+                <xs:annotation>
+                    <xs:documentation>Independent JPEG Group License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="IJG-short">
+                <xs:annotation>
+                    <xs:documentation>Independent JPEG Group License - short</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ImageMagick">
+                <xs:annotation>
+                    <xs:documentation>ImageMagick License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="iMatix">
+                <xs:annotation>
+                    <xs:documentation>iMatix Standard Function Library Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Imlib2">
+                <xs:annotation>
+                    <xs:documentation>Imlib2 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Info-ZIP">
+                <xs:annotation>
+                    <xs:documentation>Info-ZIP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Inner-Net-2.0">
+                <xs:annotation>
+                    <xs:documentation>Inner Net License v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="InnoSetup">
+                <xs:annotation>
+                    <xs:documentation>Inno Setup License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Intel">
+                <xs:annotation>
+                    <xs:documentation>Intel Open Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Intel-ACPI">
+                <xs:annotation>
+                    <xs:documentation>Intel ACPI Software License Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Interbase-1.0">
+                <xs:annotation>
+                    <xs:documentation>Interbase Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="IPA">
+                <xs:annotation>
+                    <xs:documentation>IPA Font License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="IPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>IBM Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ISC">
+                <xs:annotation>
+                    <xs:documentation>ISC License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ISC-Veillard">
+                <xs:annotation>
+                    <xs:documentation>ISC Veillard variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ISO-permission">
+                <xs:annotation>
+                    <xs:documentation>ISO permission notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Jam">
+                <xs:annotation>
+                    <xs:documentation>Jam License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="JasPer-2.0">
+                <xs:annotation>
+                    <xs:documentation>JasPer License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="jove">
+                <xs:annotation>
+                    <xs:documentation>Jove License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="JPL-image">
+                <xs:annotation>
+                    <xs:documentation>JPL Image Use Policy</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="JPNIC">
+                <xs:annotation>
+                    <xs:documentation>Japan Network Information Center License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="JSON">
+                <xs:annotation>
+                    <xs:documentation>JSON License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Kastrup">
+                <xs:annotation>
+                    <xs:documentation>Kastrup License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Kazlib">
+                <xs:annotation>
+                    <xs:documentation>Kazlib License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Knuth-CTAN">
+                <xs:annotation>
+                    <xs:documentation>Knuth CTAN License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LAL-1.2">
+                <xs:annotation>
+                    <xs:documentation>Licence Art Libre 1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LAL-1.3">
+                <xs:annotation>
+                    <xs:documentation>Licence Art Libre 1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Latex2e">
+                <xs:annotation>
+                    <xs:documentation>Latex2e License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Latex2e-translated-notice">
+                <xs:annotation>
+                    <xs:documentation>Latex2e with translated notice permission</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Leptonica">
+                <xs:annotation>
+                    <xs:documentation>Leptonica License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.0">
+                <xs:annotation>
+                    <xs:documentation>GNU Library General Public License v2 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.0+">
+                <xs:annotation>
+                    <xs:documentation>GNU Library General Public License v2 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.0-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Library General Public License v2 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Library General Public License v2 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.1">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v2.1 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.1+">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v2.1 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.1-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v2.1 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-2.1-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v2.1 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-3.0">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v3.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-3.0+">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v3.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-3.0-only">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v3.0 only</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-3.0-or-later">
+                <xs:annotation>
+                    <xs:documentation>GNU Lesser General Public License v3.0 or later</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPLLR">
+                <xs:annotation>
+                    <xs:documentation>Lesser General Public License For Linguistic Resources</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Libpng">
+                <xs:annotation>
+                    <xs:documentation>libpng License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="libpng-1.6.35">
+                <xs:annotation>
+                    <xs:documentation>PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="libpng-2.0">
+                <xs:annotation>
+                    <xs:documentation>PNG Reference Library version 2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="libselinux-1.0">
+                <xs:annotation>
+                    <xs:documentation>libselinux public domain notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="libtiff">
+                <xs:annotation>
+                    <xs:documentation>libtiff License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="libutil-David-Nugent">
+                <xs:annotation>
+                    <xs:documentation>libutil David Nugent License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LiLiQ-P-1.1">
+                <xs:annotation>
+                    <xs:documentation>Licence Libre du Québec – Permissive version 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LiLiQ-R-1.1">
+                <xs:annotation>
+                    <xs:documentation>Licence Libre du Québec – Réciprocité version 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LiLiQ-Rplus-1.1">
+                <xs:annotation>
+                    <xs:documentation>Licence Libre du Québec – Réciprocité forte version 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Linux-man-pages-1-para">
+                <xs:annotation>
+                    <xs:documentation>Linux man-pages - 1 paragraph</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Linux-man-pages-copyleft">
+                <xs:annotation>
+                    <xs:documentation>Linux man-pages Copyleft</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Linux-man-pages-copyleft-2-para">
+                <xs:annotation>
+                    <xs:documentation>Linux man-pages Copyleft - 2 paragraphs</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Linux-man-pages-copyleft-var">
+                <xs:annotation>
+                    <xs:documentation>Linux man-pages Copyleft Variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Linux-OpenIB">
+                <xs:annotation>
+                    <xs:documentation>Linux Kernel Variant of OpenIB.org license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LOOP">
+                <xs:annotation>
+                    <xs:documentation>Common Lisp LOOP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPD-document">
+                <xs:annotation>
+                    <xs:documentation>LPD Documentation License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Lucent Public License Version 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPL-1.02">
+                <xs:annotation>
+                    <xs:documentation>Lucent Public License v1.02</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>LaTeX Project Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>LaTeX Project Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPPL-1.2">
+                <xs:annotation>
+                    <xs:documentation>LaTeX Project Public License v1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPPL-1.3a">
+                <xs:annotation>
+                    <xs:documentation>LaTeX Project Public License v1.3a</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LPPL-1.3c">
+                <xs:annotation>
+                    <xs:documentation>LaTeX Project Public License v1.3c</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="lsof">
+                <xs:annotation>
+                    <xs:documentation>lsof License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Lucida-Bitmap-Fonts">
+                <xs:annotation>
+                    <xs:documentation>Lucida Bitmap Fonts License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LZMA-SDK-9.11-to-9.20">
+                <xs:annotation>
+                    <xs:documentation>LZMA SDK License (versions 9.11 to 9.20)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LZMA-SDK-9.22">
+                <xs:annotation>
+                    <xs:documentation>LZMA SDK License (versions 9.22 and beyond)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Mackerras-3-Clause">
+                <xs:annotation>
+                    <xs:documentation>Mackerras 3-Clause License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Mackerras-3-Clause-acknowledgment">
+                <xs:annotation>
+                    <xs:documentation>Mackerras 3-Clause - acknowledgment variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="magaz">
+                <xs:annotation>
+                    <xs:documentation>magaz License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mailprio">
+                <xs:annotation>
+                    <xs:documentation>mailprio License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MakeIndex">
+                <xs:annotation>
+                    <xs:documentation>MakeIndex License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="man2html">
+                <xs:annotation>
+                    <xs:documentation>man2html License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Martin-Birgmeier">
+                <xs:annotation>
+                    <xs:documentation>Martin Birgmeier License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="McPhee-slideshow">
+                <xs:annotation>
+                    <xs:documentation>McPhee Slideshow License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="metamail">
+                <xs:annotation>
+                    <xs:documentation>metamail License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Minpack">
+                <xs:annotation>
+                    <xs:documentation>Minpack License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIPS">
+                <xs:annotation>
+                    <xs:documentation>MIPS License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MirOS">
+                <xs:annotation>
+                    <xs:documentation>The MirOS Licence</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT">
+                <xs:annotation>
+                    <xs:documentation>MIT License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-0">
+                <xs:annotation>
+                    <xs:documentation>MIT No Attribution</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-advertising">
+                <xs:annotation>
+                    <xs:documentation>Enlightenment License (e16)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-Click">
+                <xs:annotation>
+                    <xs:documentation>MIT Click License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-CMU">
+                <xs:annotation>
+                    <xs:documentation>CMU License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-enna">
+                <xs:annotation>
+                    <xs:documentation>enna License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-feh">
+                <xs:annotation>
+                    <xs:documentation>feh License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-Festival">
+                <xs:annotation>
+                    <xs:documentation>MIT Festival Variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-Khronos-old">
+                <xs:annotation>
+                    <xs:documentation>MIT Khronos - old variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-Modern-Variant">
+                <xs:annotation>
+                    <xs:documentation>MIT License Modern Variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-open-group">
+                <xs:annotation>
+                    <xs:documentation>MIT Open Group variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-STK">
+                <xs:annotation>
+                    <xs:documentation>MIT-STK License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-testregex">
+                <xs:annotation>
+                    <xs:documentation>MIT testregex Variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MIT-Wu">
+                <xs:annotation>
+                    <xs:documentation>MIT Tom Wu Variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MITNFA">
+                <xs:annotation>
+                    <xs:documentation>MIT +no-false-attribs license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MMIXware">
+                <xs:annotation>
+                    <xs:documentation>MMIXware License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MMPL-1.0.1">
+                <xs:annotation>
+                    <xs:documentation>Minecraft Mod Public License v1.0.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Motosoto">
+                <xs:annotation>
+                    <xs:documentation>Motosoto License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MPEG-SSG">
+                <xs:annotation>
+                    <xs:documentation>MPEG Software Simulation</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mpi-permissive">
+                <xs:annotation>
+                    <xs:documentation>mpi Permissive License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mpich2">
+                <xs:annotation>
+                    <xs:documentation>mpich2 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Mozilla Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Mozilla Public License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MPL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Mozilla Public License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MPL-2.0-no-copyleft-exception">
+                <xs:annotation>
+                    <xs:documentation>Mozilla Public License 2.0 (no copyleft exception)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mplus">
+                <xs:annotation>
+                    <xs:documentation>mplus Font License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MS-LPL">
+                <xs:annotation>
+                    <xs:documentation>Microsoft Limited Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MS-PL">
+                <xs:annotation>
+                    <xs:documentation>Microsoft Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MS-RL">
+                <xs:annotation>
+                    <xs:documentation>Microsoft Reciprocal License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MTLL">
+                <xs:annotation>
+                    <xs:documentation>Matrix Template Library License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MulanPSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Mulan Permissive Software License, Version 1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MulanPSL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Mulan Permissive Software License, Version 2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Multics">
+                <xs:annotation>
+                    <xs:documentation>Multics License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Mup">
+                <xs:annotation>
+                    <xs:documentation>Mup License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NAIST-2003">
+                <xs:annotation>
+                    <xs:documentation>Nara Institute of Science and Technology License (2003)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NASA-1.3">
+                <xs:annotation>
+                    <xs:documentation>NASA Open Source Agreement 1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Naumen">
+                <xs:annotation>
+                    <xs:documentation>Naumen Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NBPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Net Boolean Public License v1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NCBI-PD">
+                <xs:annotation>
+                    <xs:documentation>NCBI Public Domain Notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NCGL-UK-2.0">
+                <xs:annotation>
+                    <xs:documentation>Non-Commercial Government Licence</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NCL">
+                <xs:annotation>
+                    <xs:documentation>NCL Source Code License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NCSA">
+                <xs:annotation>
+                    <xs:documentation>University of Illinois/NCSA Open Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Net-SNMP">
+                <xs:annotation>
+                    <xs:documentation>Net-SNMP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NetCDF">
+                <xs:annotation>
+                    <xs:documentation>NetCDF license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Newsletr">
+                <xs:annotation>
+                    <xs:documentation>Newsletr License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NGPL">
+                <xs:annotation>
+                    <xs:documentation>Nethack General Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ngrep">
+                <xs:annotation>
+                    <xs:documentation>ngrep License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NICTA-1.0">
+                <xs:annotation>
+                    <xs:documentation>NICTA Public Software License, Version 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NIST-PD">
+                <xs:annotation>
+                    <xs:documentation>NIST Public Domain Notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NIST-PD-fallback">
+                <xs:annotation>
+                    <xs:documentation>NIST Public Domain Notice with license fallback</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NIST-PD-TNT">
+                <xs:annotation>
+                    <xs:documentation>NIST    Public Domain Notice TNT variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NIST-Software">
+                <xs:annotation>
+                    <xs:documentation>NIST Software License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NLOD-1.0">
+                <xs:annotation>
+                    <xs:documentation>Norwegian Licence for Open Government Data (NLOD) 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NLOD-2.0">
+                <xs:annotation>
+                    <xs:documentation>Norwegian Licence for Open Government Data (NLOD) 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NLPL">
+                <xs:annotation>
+                    <xs:documentation>No Limit Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Nokia">
+                <xs:annotation>
+                    <xs:documentation>Nokia Open Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NOSL">
+                <xs:annotation>
+                    <xs:documentation>Netizen Open Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Noweb">
+                <xs:annotation>
+                    <xs:documentation>Noweb License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Netscape Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Netscape Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NPOSL-3.0">
+                <xs:annotation>
+                    <xs:documentation>Non-Profit Open Software License 3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NRL">
+                <xs:annotation>
+                    <xs:documentation>NRL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NTIA-PD">
+                <xs:annotation>
+                    <xs:documentation>NTIA Public Domain Notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NTP">
+                <xs:annotation>
+                    <xs:documentation>NTP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NTP-0">
+                <xs:annotation>
+                    <xs:documentation>NTP No Attribution</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Nunit">
+                <xs:annotation>
+                    <xs:documentation>Nunit License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="O-UDA-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Use of Data Agreement v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OAR">
+                <xs:annotation>
+                    <xs:documentation>OAR License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OCCT-PL">
+                <xs:annotation>
+                    <xs:documentation>Open CASCADE Technology Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OCLC-2.0">
+                <xs:annotation>
+                    <xs:documentation>OCLC Research Public License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ODbL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Data Commons Open Database License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ODC-By-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Data Commons Attribution License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFFIS">
+                <xs:annotation>
+                    <xs:documentation>OFFIS License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFL-1.0">
+                <xs:annotation>
+                    <xs:documentation>SIL Open Font License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFL-1.0-no-RFN">
+                <xs:annotation>
+                    <xs:documentation>SIL Open Font License 1.0 with no Reserved Font Name</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFL-1.0-RFN">
+                <xs:annotation>
+                    <xs:documentation>SIL Open Font License 1.0 with Reserved Font Name</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFL-1.1">
+                <xs:annotation>
+                    <xs:documentation>SIL Open Font License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFL-1.1-no-RFN">
+                <xs:annotation>
+                    <xs:documentation>SIL Open Font License 1.1 with no Reserved Font Name</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OFL-1.1-RFN">
+                <xs:annotation>
+                    <xs:documentation>SIL Open Font License 1.1 with Reserved Font Name</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGC-1.0">
+                <xs:annotation>
+                    <xs:documentation>OGC Software License, Version 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGDL-Taiwan-1.0">
+                <xs:annotation>
+                    <xs:documentation>Taiwan Open Government Data License, version 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGL-Canada-2.0">
+                <xs:annotation>
+                    <xs:documentation>Open Government Licence - Canada</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGL-UK-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Government Licence v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGL-UK-2.0">
+                <xs:annotation>
+                    <xs:documentation>Open Government Licence v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGL-UK-3.0">
+                <xs:annotation>
+                    <xs:documentation>Open Government Licence v3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OGTSL">
+                <xs:annotation>
+                    <xs:documentation>Open Group Test Suite License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-1.1">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-1.2">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-1.3">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-1.4">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v1.4</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.0">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.0.1">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.0.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.1">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.2">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.2.1">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.2.2">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License 2.2.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.3">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.4">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.4</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.5">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.5</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.6">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.6</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.7">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.7</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLDAP-2.8">
+                <xs:annotation>
+                    <xs:documentation>Open LDAP Public License v2.8</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OLFL-1.3">
+                <xs:annotation>
+                    <xs:documentation>Open Logistics Foundation License Version 1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OML">
+                <xs:annotation>
+                    <xs:documentation>Open Market License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OpenMDW-1.0">
+                <xs:annotation>
+                    <xs:documentation>OpenMDW License Agreement v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OpenPBS-2.3">
+                <xs:annotation>
+                    <xs:documentation>OpenPBS v2.3 Software License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OpenSSL">
+                <xs:annotation>
+                    <xs:documentation>OpenSSL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OpenSSL-standalone">
+                <xs:annotation>
+                    <xs:documentation>OpenSSL License - standalone</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OpenVision">
+                <xs:annotation>
+                    <xs:documentation>OpenVision License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OPL-UK-3.0">
+                <xs:annotation>
+                    <xs:documentation>United    Kingdom Open Parliament Licence v3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OPUBL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Publication License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSC-1.0">
+                <xs:annotation>
+                    <xs:documentation>OSC License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSET-PL-2.1">
+                <xs:annotation>
+                    <xs:documentation>OSET Public License version 2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Software License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Open Software License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Open Software License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSL-2.1">
+                <xs:annotation>
+                    <xs:documentation>Open Software License 2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSL-3.0">
+                <xs:annotation>
+                    <xs:documentation>Open Software License 3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OSSP">
+                <xs:annotation>
+                    <xs:documentation>OSSP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PADL">
+                <xs:annotation>
+                    <xs:documentation>PADL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ParaType-Free-Font-1.3">
+                <xs:annotation>
+                    <xs:documentation>ParaType Free Font Licensing Agreement v1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Parity-6.0.0">
+                <xs:annotation>
+                    <xs:documentation>The Parity Public License 6.0.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Parity-7.0.0">
+                <xs:annotation>
+                    <xs:documentation>The Parity Public License 7.0.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PDDL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open Data Commons Public Domain Dedication &amp; License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PHP-3.0">
+                <xs:annotation>
+                    <xs:documentation>PHP License v3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PHP-3.01">
+                <xs:annotation>
+                    <xs:documentation>PHP License v3.01</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Pixar">
+                <xs:annotation>
+                    <xs:documentation>Pixar License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="pkgconf">
+                <xs:annotation>
+                    <xs:documentation>pkgconf License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Plexus">
+                <xs:annotation>
+                    <xs:documentation>Plexus Classworlds License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="pnmstitch">
+                <xs:annotation>
+                    <xs:documentation>pnmstitch License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PolyForm-Noncommercial-1.0.0">
+                <xs:annotation>
+                    <xs:documentation>PolyForm Noncommercial License 1.0.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PolyForm-Small-Business-1.0.0">
+                <xs:annotation>
+                    <xs:documentation>PolyForm Small Business License 1.0.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PostgreSQL">
+                <xs:annotation>
+                    <xs:documentation>PostgreSQL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PPL">
+                <xs:annotation>
+                    <xs:documentation>Peer Production License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PSF-2.0">
+                <xs:annotation>
+                    <xs:documentation>Python Software Foundation License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="psfrag">
+                <xs:annotation>
+                    <xs:documentation>psfrag License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="psutils">
+                <xs:annotation>
+                    <xs:documentation>psutils License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Python-2.0">
+                <xs:annotation>
+                    <xs:documentation>Python License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Python-2.0.1">
+                <xs:annotation>
+                    <xs:documentation>Python License 2.0.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="python-ldap">
+                <xs:annotation>
+                    <xs:documentation>Python ldap License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Qhull">
+                <xs:annotation>
+                    <xs:documentation>Qhull License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="QPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Q Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="QPL-1.0-INRIA-2004">
+                <xs:annotation>
+                    <xs:documentation>Q Public License 1.0 - INRIA 2004 variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="radvd">
+                <xs:annotation>
+                    <xs:documentation>radvd License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Rdisc">
+                <xs:annotation>
+                    <xs:documentation>Rdisc License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RHeCos-1.1">
+                <xs:annotation>
+                    <xs:documentation>Red Hat eCos Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Reciprocal Public License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RPL-1.5">
+                <xs:annotation>
+                    <xs:documentation>Reciprocal Public License 1.5</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RPSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>RealNetworks Public Source License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RSA-MD">
+                <xs:annotation>
+                    <xs:documentation>RSA Message-Digest License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RSCPL">
+                <xs:annotation>
+                    <xs:documentation>Ricoh Source Code Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ruby">
+                <xs:annotation>
+                    <xs:documentation>Ruby License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ruby-pty">
+                <xs:annotation>
+                    <xs:documentation>Ruby pty extension license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SAX-PD">
+                <xs:annotation>
+                    <xs:documentation>Sax Public Domain Notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SAX-PD-2.0">
+                <xs:annotation>
+                    <xs:documentation>Sax Public Domain Notice 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Saxpath">
+                <xs:annotation>
+                    <xs:documentation>Saxpath License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SCEA">
+                <xs:annotation>
+                    <xs:documentation>SCEA Shared Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SchemeReport">
+                <xs:annotation>
+                    <xs:documentation>Scheme Language Report License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sendmail">
+                <xs:annotation>
+                    <xs:documentation>Sendmail License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sendmail-8.23">
+                <xs:annotation>
+                    <xs:documentation>Sendmail License 8.23</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sendmail-Open-Source-1.1">
+                <xs:annotation>
+                    <xs:documentation>Sendmail Open Source License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SGI-B-1.0">
+                <xs:annotation>
+                    <xs:documentation>SGI Free Software License B v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SGI-B-1.1">
+                <xs:annotation>
+                    <xs:documentation>SGI Free Software License B v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SGI-B-2.0">
+                <xs:annotation>
+                    <xs:documentation>SGI Free Software License B v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SGI-OpenGL">
+                <xs:annotation>
+                    <xs:documentation>SGI OpenGL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SGMLUG-PM">
+                <xs:annotation>
+                    <xs:documentation>SGMLUG Parser Materials License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SGP4">
+                <xs:annotation>
+                    <xs:documentation>SGP4 Permission Notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SHL-0.5">
+                <xs:annotation>
+                    <xs:documentation>Solderpad Hardware License v0.5</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SHL-0.51">
+                <xs:annotation>
+                    <xs:documentation>Solderpad Hardware License, Version 0.51</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SimPL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Simple Public License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SISSL">
+                <xs:annotation>
+                    <xs:documentation>Sun Industry Standards Source License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SISSL-1.2">
+                <xs:annotation>
+                    <xs:documentation>Sun Industry Standards Source License v1.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SL">
+                <xs:annotation>
+                    <xs:documentation>SL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sleepycat">
+                <xs:annotation>
+                    <xs:documentation>Sleepycat License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SMAIL-GPL">
+                <xs:annotation>
+                    <xs:documentation>SMAIL General Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SMLNJ">
+                <xs:annotation>
+                    <xs:documentation>Standard ML of New Jersey License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SMPPL">
+                <xs:annotation>
+                    <xs:documentation>Secure Messaging Protocol Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SNIA">
+                <xs:annotation>
+                    <xs:documentation>SNIA Public License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="snprintf">
+                <xs:annotation>
+                    <xs:documentation>snprintf License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SOFA">
+                <xs:annotation>
+                    <xs:documentation>SOFA Software License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="softSurfer">
+                <xs:annotation>
+                    <xs:documentation>softSurfer License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Soundex">
+                <xs:annotation>
+                    <xs:documentation>Soundex License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Spencer-86">
+                <xs:annotation>
+                    <xs:documentation>Spencer License 86</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Spencer-94">
+                <xs:annotation>
+                    <xs:documentation>Spencer License 94</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Spencer-99">
+                <xs:annotation>
+                    <xs:documentation>Spencer License 99</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Sun Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ssh-keyscan">
+                <xs:annotation>
+                    <xs:documentation>ssh-keyscan License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SSH-OpenSSH">
+                <xs:annotation>
+                    <xs:documentation>SSH OpenSSH license</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SSH-short">
+                <xs:annotation>
+                    <xs:documentation>SSH short notice</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SSLeay-standalone">
+                <xs:annotation>
+                    <xs:documentation>SSLeay License - standalone</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SSPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Server Side Public License, v 1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="StandardML-NJ">
+                <xs:annotation>
+                    <xs:documentation>Standard ML of New Jersey License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SugarCRM-1.1.3">
+                <xs:annotation>
+                    <xs:documentation>SugarCRM Public License v1.1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SUL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Sustainable Use License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sun-PPP">
+                <xs:annotation>
+                    <xs:documentation>Sun PPP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Sun-PPP-2000">
+                <xs:annotation>
+                    <xs:documentation>Sun PPP License (2000)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SunPro">
+                <xs:annotation>
+                    <xs:documentation>SunPro License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SWL">
+                <xs:annotation>
+                    <xs:documentation>Scheme Widget Library (SWL) Software License Agreement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="swrule">
+                <xs:annotation>
+                    <xs:documentation>swrule License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Symlinks">
+                <xs:annotation>
+                    <xs:documentation>Symlinks License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TAPR-OHL-1.0">
+                <xs:annotation>
+                    <xs:documentation>TAPR Open Hardware License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TCL">
+                <xs:annotation>
+                    <xs:documentation>TCL/TK License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TCP-wrappers">
+                <xs:annotation>
+                    <xs:documentation>TCP Wrappers License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TekHVC">
+                <xs:annotation>
+                    <xs:documentation>TekHVC License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TermReadKey">
+                <xs:annotation>
+                    <xs:documentation>TermReadKey License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TGPPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Transitive Grace Period Public Licence 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ThirdEye">
+                <xs:annotation>
+                    <xs:documentation>ThirdEye License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="threeparttable">
+                <xs:annotation>
+                    <xs:documentation>threeparttable License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TMate">
+                <xs:annotation>
+                    <xs:documentation>TMate Open Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TORQUE-1.1">
+                <xs:annotation>
+                    <xs:documentation>TORQUE v2.5+ Software License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TOSL">
+                <xs:annotation>
+                    <xs:documentation>Trusster Open Source License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TPDL">
+                <xs:annotation>
+                    <xs:documentation>Time::ParseDate License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>THOR Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TrustedQSL">
+                <xs:annotation>
+                    <xs:documentation>TrustedQSL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TTWL">
+                <xs:annotation>
+                    <xs:documentation>Text-Tabs+Wrap License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TTYP0">
+                <xs:annotation>
+                    <xs:documentation>TTYP0 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TU-Berlin-1.0">
+                <xs:annotation>
+                    <xs:documentation>Technische Universitaet Berlin License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="TU-Berlin-2.0">
+                <xs:annotation>
+                    <xs:documentation>Technische Universitaet Berlin License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Ubuntu-font-1.0">
+                <xs:annotation>
+                    <xs:documentation>Ubuntu Font Licence v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UCAR">
+                <xs:annotation>
+                    <xs:documentation>UCAR License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UCL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Upstream Compatibility License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ulem">
+                <xs:annotation>
+                    <xs:documentation>ulem License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UMich-Merit">
+                <xs:annotation>
+                    <xs:documentation>Michigan/Merit Networks License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unicode-3.0">
+                <xs:annotation>
+                    <xs:documentation>Unicode License v3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unicode-DFS-2015">
+                <xs:annotation>
+                    <xs:documentation>Unicode License Agreement - Data Files and Software (2015)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unicode-DFS-2016">
+                <xs:annotation>
+                    <xs:documentation>Unicode License Agreement - Data Files and Software (2016)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unicode-TOU">
+                <xs:annotation>
+                    <xs:documentation>Unicode Terms of Use</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UnixCrypt">
+                <xs:annotation>
+                    <xs:documentation>UnixCrypt License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unlicense">
+                <xs:annotation>
+                    <xs:documentation>The Unlicense</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unlicense-libtelnet">
+                <xs:annotation>
+                    <xs:documentation>Unlicense - libtelnet variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Unlicense-libwhirlpool">
+                <xs:annotation>
+                    <xs:documentation>Unlicense - libwhirlpool variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UnRAR">
+                <xs:annotation>
+                    <xs:documentation>UnRAR License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Universal Permissive License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="URT-RLE">
+                <xs:annotation>
+                    <xs:documentation>Utah Raster Toolkit Run Length Encoded License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Vim">
+                <xs:annotation>
+                    <xs:documentation>Vim License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Vixie-Cron">
+                <xs:annotation>
+                    <xs:documentation>Vixie Cron License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="VOSTROM">
+                <xs:annotation>
+                    <xs:documentation>VOSTROM Public License for Open Source</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="VSL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Vovida Software License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="W3C">
+                <xs:annotation>
+                    <xs:documentation>W3C Software Notice and License (2002-12-31)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="W3C-19980720">
+                <xs:annotation>
+                    <xs:documentation>W3C Software Notice and License (1998-07-20)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="W3C-20150513">
+                <xs:annotation>
+                    <xs:documentation>W3C Software Notice and Document License (2015-05-13)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="w3m">
+                <xs:annotation>
+                    <xs:documentation>w3m License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Watcom-1.0">
+                <xs:annotation>
+                    <xs:documentation>Sybase Open Watcom Public License 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Widget-Workshop">
+                <xs:annotation>
+                    <xs:documentation>Widget Workshop License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="WordNet">
+                <xs:annotation>
+                    <xs:documentation>WordNet License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Wsuipa">
+                <xs:annotation>
+                    <xs:documentation>Wsuipa License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="WTFNMFPL">
+                <xs:annotation>
+                    <xs:documentation>Do What The F*ck You Want To But It&apos;s Not My Fault Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="WTFPL">
+                <xs:annotation>
+                    <xs:documentation>Do What The F*ck You Want To Public License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="wwl">
+                <xs:annotation>
+                    <xs:documentation>WWL License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="wxWindows">
+                <xs:annotation>
+                    <xs:documentation>wxWindows Library License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="X11">
+                <xs:annotation>
+                    <xs:documentation>X11 License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="X11-distribute-modifications-variant">
+                <xs:annotation>
+                    <xs:documentation>X11 License Distribution Modification Variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="X11-no-permit-persons">
+                <xs:annotation>
+                    <xs:documentation>X11 no permit persons clause</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="X11-swapped">
+                <xs:annotation>
+                    <xs:documentation>X11 swapped final paragraphs</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Xdebug-1.03">
+                <xs:annotation>
+                    <xs:documentation>Xdebug License v 1.03</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Xerox">
+                <xs:annotation>
+                    <xs:documentation>Xerox License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Xfig">
+                <xs:annotation>
+                    <xs:documentation>Xfig License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="XFree86-1.1">
+                <xs:annotation>
+                    <xs:documentation>XFree86 License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="xinetd">
+                <xs:annotation>
+                    <xs:documentation>xinetd License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="xkeyboard-config-Zinoviev">
+                <xs:annotation>
+                    <xs:documentation>xkeyboard-config Zinoviev License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="xlock">
+                <xs:annotation>
+                    <xs:documentation>xlock License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Xnet">
+                <xs:annotation>
+                    <xs:documentation>X.Net License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="xpp">
+                <xs:annotation>
+                    <xs:documentation>XPP License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="XSkat">
+                <xs:annotation>
+                    <xs:documentation>XSkat License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="xzoom">
+                <xs:annotation>
+                    <xs:documentation>xzoom License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="YPL-1.0">
+                <xs:annotation>
+                    <xs:documentation>Yahoo! Public License v1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="YPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Yahoo! Public License v1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Zed">
+                <xs:annotation>
+                    <xs:documentation>Zed License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Zeeff">
+                <xs:annotation>
+                    <xs:documentation>Zeeff License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Zend-2.0">
+                <xs:annotation>
+                    <xs:documentation>Zend License v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Zimbra-1.3">
+                <xs:annotation>
+                    <xs:documentation>Zimbra Public License v1.3</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Zimbra-1.4">
+                <xs:annotation>
+                    <xs:documentation>Zimbra Public License v1.4</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Zlib">
+                <xs:annotation>
+                    <xs:documentation>zlib License</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="zlib-acknowledgement">
+                <xs:annotation>
+                    <xs:documentation>zlib/libpng License with Acknowledgement</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ZPL-1.1">
+                <xs:annotation>
+                    <xs:documentation>Zope Public License 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ZPL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Zope Public License 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ZPL-2.1">
+                <xs:annotation>
+                    <xs:documentation>Zope Public License 2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <!-- Exceptions -->
+            <xs:enumeration value="389-exception">
+                <xs:annotation>
+                    <xs:documentation>389 Directory Server Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Asterisk-exception">
+                <xs:annotation>
+                    <xs:documentation>Asterisk exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Asterisk-linking-protocols-exception">
+                <xs:annotation>
+                    <xs:documentation>Asterisk linking protocols exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Autoconf-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>Autoconf exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Autoconf-exception-3.0">
+                <xs:annotation>
+                    <xs:documentation>Autoconf exception 3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Autoconf-exception-generic">
+                <xs:annotation>
+                    <xs:documentation>Autoconf generic exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Autoconf-exception-generic-3.0">
+                <xs:annotation>
+                    <xs:documentation>Autoconf generic exception for GPL-3.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Autoconf-exception-macro">
+                <xs:annotation>
+                    <xs:documentation>Autoconf macro exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Bison-exception-1.24">
+                <xs:annotation>
+                    <xs:documentation>Bison exception 1.24</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Bison-exception-2.2">
+                <xs:annotation>
+                    <xs:documentation>Bison exception 2.2</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Bootloader-exception">
+                <xs:annotation>
+                    <xs:documentation>Bootloader Distribution Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CGAL-linking-exception">
+                <xs:annotation>
+                    <xs:documentation>CGAL Linking Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Classpath-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>Classpath exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Classpath-exception-2.0-short">
+                <xs:annotation>
+                    <xs:documentation>Classpath exception 2.0 - short</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="CLISP-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>CLISP exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cryptsetup-OpenSSL-exception">
+                <xs:annotation>
+                    <xs:documentation>cryptsetup OpenSSL exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Digia-Qt-LGPL-exception-1.1">
+                <xs:annotation>
+                    <xs:documentation>Digia Qt LGPL Exception version 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DigiRule-FOSS-exception">
+                <xs:annotation>
+                    <xs:documentation>DigiRule FOSS License Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="eCos-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>eCos exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="erlang-otp-linking-exception">
+                <xs:annotation>
+                    <xs:documentation>Erlang/OTP Linking Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Fawkes-Runtime-exception">
+                <xs:annotation>
+                    <xs:documentation>Fawkes Runtime Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="FLTK-exception">
+                <xs:annotation>
+                    <xs:documentation>FLTK exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="fmt-exception">
+                <xs:annotation>
+                    <xs:documentation>fmt exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Font-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>Font exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="freertos-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>FreeRTOS Exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GCC-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>GCC Runtime Library exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GCC-exception-2.0-note">
+                <xs:annotation>
+                    <xs:documentation>GCC    Runtime Library exception 2.0 - note variant</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GCC-exception-3.1">
+                <xs:annotation>
+                    <xs:documentation>GCC Runtime Library exception 3.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Gmsh-exception">
+                <xs:annotation>
+                    <xs:documentation>Gmsh exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GNAT-exception">
+                <xs:annotation>
+                    <xs:documentation>GNAT exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GNOME-examples-exception">
+                <xs:annotation>
+                    <xs:documentation>GNOME examples exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GNU-compiler-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU Compiler Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="gnu-javamail-exception">
+                <xs:annotation>
+                    <xs:documentation>GNU JavaMail exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-389-ds-base-exception">
+                <xs:annotation>
+                    <xs:documentation>GPL-3.0 389 DS Base Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-interface-exception">
+                <xs:annotation>
+                    <xs:documentation>GPL-3.0 Interface Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-linking-exception">
+                <xs:annotation>
+                    <xs:documentation>GPL-3.0 Linking Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-3.0-linking-source-exception">
+                <xs:annotation>
+                    <xs:documentation>GPL-3.0 Linking Exception (with Corresponding Source)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GPL-CC-1.0">
+                <xs:annotation>
+                    <xs:documentation>GPL Cooperation Commitment 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GStreamer-exception-2005">
+                <xs:annotation>
+                    <xs:documentation>GStreamer Exception (2005)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GStreamer-exception-2008">
+                <xs:annotation>
+                    <xs:documentation>GStreamer Exception (2008)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="harbour-exception">
+                <xs:annotation>
+                    <xs:documentation>harbour exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="i2p-gpl-java-exception">
+                <xs:annotation>
+                    <xs:documentation>i2p GPL+Java Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Independent-modules-exception">
+                <xs:annotation>
+                    <xs:documentation>Independent Module Linking exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="KiCad-libraries-exception">
+                <xs:annotation>
+                    <xs:documentation>KiCad Libraries Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="kvirc-openssl-exception">
+                <xs:annotation>
+                    <xs:documentation>kvirc OpenSSL Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LGPL-3.0-linking-exception">
+                <xs:annotation>
+                    <xs:documentation>LGPL-3.0 Linking Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="libpri-OpenH323-exception">
+                <xs:annotation>
+                    <xs:documentation>libpri OpenH323 exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Libtool-exception">
+                <xs:annotation>
+                    <xs:documentation>Libtool Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Linux-syscall-note">
+                <xs:annotation>
+                    <xs:documentation>Linux Syscall Note</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LLGPL">
+                <xs:annotation>
+                    <xs:documentation>LLGPL Preamble</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LLVM-exception">
+                <xs:annotation>
+                    <xs:documentation>LLVM Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LZMA-exception">
+                <xs:annotation>
+                    <xs:documentation>LZMA exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mif-exception">
+                <xs:annotation>
+                    <xs:documentation>Macros and Inline Functions Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="mxml-exception">
+                <xs:annotation>
+                    <xs:documentation>mxml Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Nokia-Qt-exception-1.1">
+                <xs:annotation>
+                    <xs:documentation>Nokia Qt LGPL exception 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OCaml-LGPL-linking-exception">
+                <xs:annotation>
+                    <xs:documentation>OCaml LGPL Linking Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OCCT-exception-1.0">
+                <xs:annotation>
+                    <xs:documentation>Open CASCADE Exception 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OpenJDK-assembly-exception-1.0">
+                <xs:annotation>
+                    <xs:documentation>OpenJDK Assembly exception 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="openvpn-openssl-exception">
+                <xs:annotation>
+                    <xs:documentation>OpenVPN OpenSSL Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PCRE2-exception">
+                <xs:annotation>
+                    <xs:documentation>PCRE2 exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="polyparse-exception">
+                <xs:annotation>
+                    <xs:documentation>Polyparse Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="PS-or-PDF-font-exception-20170817">
+                <xs:annotation>
+                    <xs:documentation>PS/PDF font exception (2017-08-17)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="QPL-1.0-INRIA-2004-exception">
+                <xs:annotation>
+                    <xs:documentation>INRIA QPL 1.0 2004 variant exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Qt-GPL-exception-1.0">
+                <xs:annotation>
+                    <xs:documentation>Qt GPL exception 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Qt-LGPL-exception-1.1">
+                <xs:annotation>
+                    <xs:documentation>Qt LGPL exception 1.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Qwt-exception-1.0">
+                <xs:annotation>
+                    <xs:documentation>Qwt exception 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="romic-exception">
+                <xs:annotation>
+                    <xs:documentation>Romic Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="RRDtool-FLOSS-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>RRDtool FLOSS exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rsync-linking-exception">
+                <xs:annotation>
+                    <xs:documentation>rsync Linking Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SANE-exception">
+                <xs:annotation>
+                    <xs:documentation>SANE Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SHL-2.0">
+                <xs:annotation>
+                    <xs:documentation>Solderpad Hardware License v2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SHL-2.1">
+                <xs:annotation>
+                    <xs:documentation>Solderpad Hardware License v2.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Simple-Library-Usage-exception">
+                <xs:annotation>
+                    <xs:documentation>Simple Library Usage Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="sqlitestudio-OpenSSL-exception">
+                <xs:annotation>
+                    <xs:documentation>sqlitestudio OpenSSL exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="stunnel-exception">
+                <xs:annotation>
+                    <xs:documentation>stunnel Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SWI-exception">
+                <xs:annotation>
+                    <xs:documentation>SWI exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Swift-exception">
+                <xs:annotation>
+                    <xs:documentation>Swift Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Texinfo-exception">
+                <xs:annotation>
+                    <xs:documentation>Texinfo exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="u-boot-exception-2.0">
+                <xs:annotation>
+                    <xs:documentation>U-Boot exception 2.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="UBDL-exception">
+                <xs:annotation>
+                    <xs:documentation>Unmodified Binary Distribution exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Universal-FOSS-exception-1.0">
+                <xs:annotation>
+                    <xs:documentation>Universal FOSS Exception, Version 1.0</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="vsftpd-openssl-exception">
+                <xs:annotation>
+                    <xs:documentation>vsftpd OpenSSL exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="WxWindows-exception-3.1">
+                <xs:annotation>
+                    <xs:documentation>WxWindows Library Exception 3.1</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="x11vnc-openssl-exception">
+                <xs:annotation>
+                    <xs:documentation>x11vnc OpenSSL Exception</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/src/sbom_validator/validator.py
+++ b/src/sbom_validator/validator.py
@@ -22,6 +22,16 @@ from sbom_validator.schema_validator import validate_schema
 logger = logging.getLogger(__name__)
 
 
+def _error_issue(message: str, rule: str = "SYS-ERROR") -> ValidationIssue:
+    """Build a consistent ERROR issue payload for tool/input failures."""
+    return ValidationIssue(
+        severity=IssueSeverity.ERROR,
+        field_path="",
+        message=message,
+        rule=rule,
+    )
+
+
 def validate(file_path: str | Path) -> ValidationResult:
     """Validate an SBOM file through the full pipeline.
 
@@ -45,11 +55,11 @@ def validate(file_path: str | Path) -> ValidationResult:
         format_name = detect_format(file_path)
         logger.info("Format detected: %s", format_name)
     except (ParseError, UnsupportedFormatError) as e:
-        logger.warning("Unexpected error during validation of %s: %s", str_path, e)
+        logger.warning("Validation input error for %s: %s", str_path, e)
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(),
+            issues=(_error_issue(str(e), rule="FR-01"),),
             format_detected=None,
         )
     except Exception as e:
@@ -57,14 +67,7 @@ def validate(file_path: str | Path) -> ValidationResult:
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(
-                ValidationIssue(
-                    severity=IssueSeverity.ERROR,
-                    field_path="",
-                    message=str(e),
-                    rule="",
-                ),
-            ),
+            issues=(_error_issue(str(e)),),
             format_detected=None,
         )
 
@@ -77,14 +80,7 @@ def validate(file_path: str | Path) -> ValidationResult:
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(
-                ValidationIssue(
-                    severity=IssueSeverity.ERROR,
-                    field_path="",
-                    message=str(e),
-                    rule="",
-                ),
-            ),
+            issues=(_error_issue(str(e)),),
             format_detected=format_name,
         )
 
@@ -109,18 +105,11 @@ def validate(file_path: str | Path) -> ValidationResult:
         else:
             sbom = parse_cyclonedx(file_path)
     except ParseError as e:
-        logger.warning("Unexpected error during validation of %s: %s", str_path, e)
+        logger.warning("Validation parse error for %s: %s", str_path, e)
         return ValidationResult(
             status=ValidationStatus.ERROR,
             file_path=str_path,
-            issues=(
-                ValidationIssue(
-                    severity=IssueSeverity.ERROR,
-                    field_path="",
-                    message=str(e),
-                    rule="",
-                ),
-            ),
+            issues=(_error_issue(str(e)),),
             format_detected=format_name,
         )
 

--- a/src/sbom_validator/validator.py
+++ b/src/sbom_validator/validator.py
@@ -71,10 +71,17 @@ def validate(file_path: str | Path) -> ValidationResult:
             format_detected=None,
         )
 
-    # Stage 1: Read raw JSON
+    # Stage 1: Read raw document
     logger.debug("Stage %s \u2192 %s", "format_detection", "schema_validation")
     try:
-        raw_doc = json.loads(file_path.read_text(encoding="utf-8"))
+        raw_text = file_path.read_text(encoding="utf-8")
+        if format_name == "spdx":
+            raw_doc: dict[str, object] | str = json.loads(raw_text)
+        else:
+            try:
+                raw_doc = json.loads(raw_text)
+            except json.JSONDecodeError:
+                raw_doc = raw_text
     except Exception as e:
         logger.error("Unexpected error during validation of %s: %s", str_path, e)
         return ValidationResult(

--- a/tests/fixtures/cyclonedx/invalid-schema.cdx.xml
+++ b/tests/fixtures/cyclonedx/invalid-schema.cdx.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
+  <metadata>
+    <timestamp>2024-01-15T10:00:00Z</timestamp>
+    <authors><author><name>AcmeCorp SBOM Team</name></author></authors>
+  </metadata>
+  <components>
+    <component bom-ref="pkg:pypi/requests@2.31.0">
+      <version>2.31.0</version>
+      <supplier><name>AcmeCorp</name></supplier>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+    </component>
+  </components>
+</bom>

--- a/tests/fixtures/cyclonedx/missing-identifiers.cdx.xml
+++ b/tests/fixtures/cyclonedx/missing-identifiers.cdx.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e" version="1">
+  <metadata>
+    <timestamp>2024-01-15T10:00:00Z</timestamp>
+    <authors><author><name>AcmeCorp SBOM Team</name></author></authors>
+    <component type="application" bom-ref="app-ref">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>MyApp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="comp-requests-2.31.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>requests</name>
+      <version>2.31.0</version>
+    </component>
+    <component type="library" bom-ref="comp-urllib3-2.1.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>urllib3</name>
+      <version>2.1.0</version>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="app-ref">
+      <dependency ref="comp-requests-2.31.0" />
+    </dependency>
+    <dependency ref="comp-requests-2.31.0">
+      <dependency ref="comp-urllib3-2.1.0" />
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/fixtures/cyclonedx/missing-relationships.cdx.xml
+++ b/tests/fixtures/cyclonedx/missing-relationships.cdx.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:5f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c" version="1">
+  <metadata>
+    <timestamp>2024-01-15T10:00:00Z</timestamp>
+    <authors><author><name>AcmeCorp SBOM Team</name></author></authors>
+    <component type="application" bom-ref="app-ref">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>MyApp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:pypi/requests@2.31.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>requests</name>
+      <version>2.31.0</version>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+    </component>
+  </components>
+  <dependencies />
+</bom>

--- a/tests/fixtures/cyclonedx/missing-supplier.cdx.xml
+++ b/tests/fixtures/cyclonedx/missing-supplier.cdx.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f" version="1">
+  <metadata>
+    <timestamp>2024-01-15T10:00:00Z</timestamp>
+    <authors><author><name>AcmeCorp SBOM Team</name></author></authors>
+    <component type="application" bom-ref="app-ref">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>MyApp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:pypi/requests@2.31.0">
+      <name>requests</name>
+      <version>2.31.0</version>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+    </component>
+    <component type="library" bom-ref="pkg:pypi/urllib3@2.1.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>urllib3</name>
+      <version>2.1.0</version>
+      <purl>pkg:pypi/urllib3@2.1.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="app-ref">
+      <dependency ref="pkg:pypi/requests@2.31.0" />
+    </dependency>
+    <dependency ref="pkg:pypi/requests@2.31.0">
+      <dependency ref="pkg:pypi/urllib3@2.1.0" />
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/fixtures/cyclonedx/missing-timestamp.cdx.xml
+++ b/tests/fixtures/cyclonedx/missing-timestamp.cdx.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d" version="1">
+  <metadata>
+    <authors><author><name>AcmeCorp SBOM Team</name></author></authors>
+    <component type="application" bom-ref="app-ref">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>MyApp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:pypi/requests@2.31.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>requests</name>
+      <version>2.31.0</version>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="app-ref">
+      <dependency ref="pkg:pypi/requests@2.31.0" />
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/fixtures/cyclonedx/valid-full.cdx.xml
+++ b/tests/fixtures/cyclonedx/valid-full.cdx.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:9f3a2b1c-4d5e-6f7a-8b9c-0d1e2f3a4b5c" version="1">
+  <metadata>
+    <timestamp>2024-01-15T10:00:00Z</timestamp>
+    <authors>
+      <author><name>AcmeCorp SBOM Team</name></author>
+    </authors>
+    <manufacture>
+      <name>AcmeCorp</name>
+    </manufacture>
+    <component type="application" bom-ref="app-webapp-2.5.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>acmecorp-webapp</name>
+      <version>2.5.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:pypi/requests@2.31.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>requests</name>
+      <version>2.31.0</version>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+      <cpe>cpe:2.3:a:python-requests:requests:2.31.0:*:*:*:*:*:*:*</cpe>
+    </component>
+    <component type="library" bom-ref="pkg:pypi/urllib3@2.1.0">
+      <supplier><name>AcmeCorp</name></supplier>
+      <name>urllib3</name>
+      <version>2.1.0</version>
+      <purl>pkg:pypi/urllib3@2.1.0</purl>
+    </component>
+    <component type="library" bom-ref="pkg:pypi/certifi@2024.2.2">
+      <supplier><name>ExampleSoft Ltd</name></supplier>
+      <name>certifi</name>
+      <version>2024.2.2</version>
+      <purl>pkg:pypi/certifi@2024.2.2</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/lodash@4.17.21">
+      <supplier><name>ExampleSoft Ltd</name></supplier>
+      <name>lodash</name>
+      <version>4.17.21</version>
+      <purl>pkg:npm/lodash@4.17.21</purl>
+      <cpe>cpe:2.3:a:lodash:lodash:4.17.21:*:*:*:*:node.js:*:*</cpe>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="app-webapp-2.5.0">
+      <dependency ref="pkg:pypi/requests@2.31.0" />
+      <dependency ref="pkg:npm/lodash@4.17.21" />
+    </dependency>
+    <dependency ref="pkg:pypi/requests@2.31.0">
+      <dependency ref="pkg:pypi/urllib3@2.1.0" />
+      <dependency ref="pkg:pypi/certifi@2024.2.2" />
+    </dependency>
+    <dependency ref="pkg:pypi/urllib3@2.1.0" />
+    <dependency ref="pkg:pypi/certifi@2024.2.2" />
+    <dependency ref="pkg:npm/lodash@4.17.21" />
+  </dependencies>
+</bom>

--- a/tests/fixtures/cyclonedx/valid-minimal.cdx.xml
+++ b/tests/fixtures/cyclonedx/valid-minimal.cdx.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
+  <metadata>
+    <timestamp>2024-01-15T10:00:00Z</timestamp>
+    <authors>
+      <author>
+        <name>AcmeCorp SBOM Team</name>
+      </author>
+    </authors>
+    <component type="application" bom-ref="app-ref">
+      <supplier>
+        <name>AcmeCorp</name>
+      </supplier>
+      <name>MyApp</name>
+      <version>1.0.0</version>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:pypi/requests@2.31.0">
+      <supplier>
+        <name>AcmeCorp</name>
+      </supplier>
+      <name>requests</name>
+      <version>2.31.0</version>
+      <purl>pkg:pypi/requests@2.31.0</purl>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="app-ref">
+      <dependency ref="pkg:pypi/requests@2.31.0" />
+    </dependency>
+  </dependencies>
+</bom>

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -49,6 +49,11 @@ class TestFullPassPipeline:
         result = runner.invoke(main, ["validate", str(CDX_FIXTURES / "valid-full.cdx.json")])
         assert result.exit_code == 0
 
+    def test_valid_cyclonedx_xml_minimal_full_pipeline(self, runner):
+        result = runner.invoke(main, ["validate", str(CDX_FIXTURES / "valid-minimal.cdx.xml")])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+
     def test_pass_json_output_structure(self, runner):
         """JSON output for a passing SBOM has all required keys."""
         result = runner.invoke(
@@ -106,6 +111,14 @@ class TestSchemaFailurePipeline:
     def test_invalid_cdx_schema_json_has_fr03_issues(self, runner):
         result = runner.invoke(
             main, ["validate", str(CDX_FIXTURES / "invalid-schema.cdx.json"), "--format", "json"]
+        )
+        data = json.loads(result.output)
+        assert data["status"] == "FAIL"
+        assert all(i["rule"] == "FR-03" for i in data["issues"])
+
+    def test_invalid_cdx_xml_schema_json_has_fr03_issues(self, runner):
+        result = runner.invoke(
+            main, ["validate", str(CDX_FIXTURES / "invalid-schema.cdx.xml"), "--format", "json"]
         )
         data = json.loads(result.output)
         assert data["status"] == "FAIL"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -133,6 +133,10 @@ class TestCliValidatePassTextOutput:
         result = runner.invoke(main, ["validate", str(CDX_FIXTURES / "valid-full.cdx.json")])
         assert result.exit_code == 0
 
+    def test_valid_cyclonedx_xml_exits_zero(self, runner: CliRunner) -> None:
+        result = runner.invoke(main, ["validate", str(CDX_FIXTURES / "valid-minimal.cdx.xml")])
+        assert result.exit_code == 0
+
 
 # ===========================================================================
 # TestCliValidateFailTextOutput
@@ -227,6 +231,20 @@ class TestCliValidateFailTextOutput:
     def test_invalid_schema_spdx_output_contains_fail(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["validate", str(SPDX_FIXTURES / "invalid-schema.spdx.json")])
         assert "FAIL" in result.output
+
+    def test_invalid_cyclonedx_xml_output_uses_human_friendly_field_path(
+        self, runner: CliRunner
+    ) -> None:
+        result = runner.invoke(main, ["validate", str(CDX_FIXTURES / "invalid-schema.cdx.xml")])
+        assert result.exit_code == 1
+        assert "/bom/components/component" in result.output
+        assert "{http://cyclonedx.org/schema/bom/1.6}" not in result.output
+
+    def test_conformance_failure_hides_ntia_rule_and_shows_hint(self, runner: CliRunner) -> None:
+        result = runner.invoke(main, ["validate", str(CDX_FIXTURES / "missing-supplier.cdx.json")])
+        assert result.exit_code == 1
+        assert "NTIA FR-" not in result.output
+        assert "Hint: provide a supplier/organization name" in result.output
 
 
 # ===========================================================================
@@ -393,6 +411,20 @@ class TestCliJsonOutputPass:
         )
         data = json.loads(result.output)
         assert data["issues"] == []
+
+    def test_valid_cyclonedx_xml_json_format_detected_is_cyclonedx(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            main,
+            [
+                "validate",
+                str(CDX_FIXTURES / "valid-minimal.cdx.xml"),
+                "--format",
+                "json",
+            ],
+        )
+        data = json.loads(result.output)
+        assert data["status"] == "PASS"
+        assert data["format_detected"] == "cyclonedx"
 
 
 # ===========================================================================

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from sbom_validator import __version__
 from sbom_validator.cli import main
 
 # ---------------------------------------------------------------------------
@@ -59,7 +60,7 @@ class TestCliVersion:
 
     def test_version_output_contains_version_string(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["--version"])
-        assert "0.1.0" in result.output
+        assert __version__ in result.output
 
 
 # ===========================================================================

--- a/tests/unit/test_cyclonedx_parser.py
+++ b/tests/unit/test_cyclonedx_parser.py
@@ -120,6 +120,15 @@ class TestParseCycloneDXBasic:
         result = parse_cyclonedx(fixtures_path / "valid-minimal.cdx.json")
         assert result.components[0].component_id == "pkg:pypi/requests@2.31.0"
 
+    def test_xml_fixture_parses_into_normalized_sbom(self, fixtures_path: Path) -> None:
+        result = parse_cyclonedx(fixtures_path / "valid-minimal.cdx.xml")
+        assert isinstance(result, NormalizedSBOM)
+        assert result.format == "cyclonedx"
+        assert len(result.components) == 1
+        assert result.components[0].name == "requests"
+        assert result.relationships[0].from_id == "app-ref"
+        assert result.relationships[0].to_id == "pkg:pypi/requests@2.31.0"
+
 
 # ---------------------------------------------------------------------------
 # TestParseCycloneDXMissingFields – graceful handling of absent optional fields

--- a/tests/unit/test_format_detector.py
+++ b/tests/unit/test_format_detector.py
@@ -1,16 +1,15 @@
 """Unit tests for sbom_validator.format_detector.
 
 Tests cover the detect_format(file_path: Path) -> str function, which inspects
-the top-level keys of a JSON file to determine whether the SBOM is in SPDX or
-CycloneDX format.
+JSON/XML input to determine whether the SBOM is in SPDX or CycloneDX format.
 
 Expected behaviour:
 - Returns "spdx" when the JSON contains a top-level "spdxVersion" key.
 - Returns "cyclonedx" when the JSON contains "bomFormat": "CycloneDX".
 - Raises UnsupportedFormatError when neither key is present or bomFormat has
   an unrecognised value.
-- Raises ParseError when the file does not exist, is empty, or contains
-  invalid JSON.
+- Raises ParseError when the file does not exist or cannot be read.
+- Raises UnsupportedFormatError for malformed/unknown content.
 
 Real fixture files are used for the happy-path detection tests; temporary
 files (via the pytest `tmp_path` fixture) are used for edge-case scenarios.
@@ -31,6 +30,7 @@ from sbom_validator.format_detector import detect_format
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 SPDX_FIXTURE = FIXTURES_DIR / "spdx" / "valid-minimal.spdx.json"
 CYCLONEDX_FIXTURE = FIXTURES_DIR / "cyclonedx" / "valid-minimal.cdx.json"
+CYCLONEDX_XML_FIXTURE = FIXTURES_DIR / "cyclonedx" / "valid-minimal.cdx.xml"
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +44,9 @@ class TestDetectFormatFromFixtures:
 
     def test_valid_cyclonedx_fixture_returns_cyclonedx(self):
         assert detect_format(CYCLONEDX_FIXTURE) == "cyclonedx"
+
+    def test_valid_cyclonedx_xml_fixture_returns_cyclonedx(self):
+        assert detect_format(CYCLONEDX_XML_FIXTURE) == "cyclonedx"
 
 
 # ---------------------------------------------------------------------------
@@ -129,16 +132,25 @@ class TestDetectFormatErrorCases:
         with pytest.raises(ParseError):
             detect_format(missing)
 
-    def test_file_with_invalid_json_raises_parse_error(self, tmp_path: Path):
+    def test_file_with_invalid_json_raises_unsupported_format_error(self, tmp_path: Path):
         f = tmp_path / "bad.json"
         f.write_text("not json {{{{", encoding="utf-8")
-        with pytest.raises(ParseError):
+        with pytest.raises(UnsupportedFormatError):
             detect_format(f)
 
     def test_empty_file_raises_parse_error(self, tmp_path: Path):
         f = tmp_path / "empty.json"
         f.write_text("", encoding="utf-8")
-        with pytest.raises(ParseError):
+        with pytest.raises(UnsupportedFormatError):
+            detect_format(f)
+
+    def test_xml_with_unsupported_namespace_raises_unsupported_format_error(self, tmp_path: Path):
+        f = tmp_path / "bad-version.cdx.xml"
+        f.write_text(
+            '<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1" />',
+            encoding="utf-8",
+        )
+        with pytest.raises(UnsupportedFormatError):
             detect_format(f)
 
     def test_file_with_json_array_raises_unsupported_format_error_or_parse_error(

--- a/tests/unit/test_ntia_checker.py
+++ b/tests/unit/test_ntia_checker.py
@@ -369,6 +369,16 @@ class TestNtiaCheckerTimestamp:
         issues = check_ntia(sbom)
         assert not any(i.rule == "FR-10" for i in issues)
 
+    def test_invalid_timestamp_string_detected(self) -> None:
+        sbom = _make_valid_sbom(timestamp="not-a-date")
+        issues = check_ntia(sbom)
+        assert any(i.rule == "FR-10" for i in issues)
+
+    def test_invalid_timestamp_format_detected(self) -> None:
+        sbom = _make_valid_sbom(timestamp="2024/01/15 10:30:00")
+        issues = check_ntia(sbom)
+        assert any(i.rule == "FR-10" for i in issues)
+
 
 # ===========================================================================
 # TestNtiaCheckerCollectAll

--- a/tests/unit/test_report_writer.py
+++ b/tests/unit/test_report_writer.py
@@ -453,7 +453,10 @@ class TestHtmlReportContent:
         assert "NTIA FR-04" not in html
         assert "provide a supplier/organization name" in html
         assert "<th>Hint</th>" in html
-        assert "Component &#x27;requests&#x27; is missing a supplier name." in html or "Component 'requests' is missing a supplier name." in html
+        assert (
+            "Component &#x27;requests&#x27; is missing a supplier name." in html
+            or "Component 'requests' is missing a supplier name." in html
+        )
 
     def test_html_places_message_and_hint_in_separate_columns(self, tmp_path: Path) -> None:
         xml_issue = ValidationIssue(
@@ -469,8 +472,14 @@ class TestHtmlReportContent:
             issues=(xml_issue,),
         )
         html = self._load_html(result, tmp_path)
-        assert "Missing required field &#x27;SPDXID&#x27;." in html or "Missing required field 'SPDXID'." in html
-        assert "add &#x27;SPDXID&#x27; at this location." in html or "add 'SPDXID' at this location." in html
+        assert (
+            "Missing required field &#x27;SPDXID&#x27;." in html
+            or "Missing required field 'SPDXID'." in html
+        )
+        assert (
+            "add &#x27;SPDXID&#x27; at this location." in html
+            or "add 'SPDXID' at this location." in html
+        )
 
 
 # ===========================================================================

--- a/tests/unit/test_report_writer.py
+++ b/tests/unit/test_report_writer.py
@@ -411,6 +411,67 @@ class TestHtmlReportContent:
         html = self._load_html(_pass_result(), tmp_path)
         assert len(html.strip()) > 0
 
+    def test_html_humanizes_xml_field_paths_and_messages(self, tmp_path: Path) -> None:
+        xml_issue = ValidationIssue(
+            severity=IssueSeverity.ERROR,
+            field_path=(
+                "/{http://cyclonedx.org/schema/bom/1.6}bom/"
+                "{http://cyclonedx.org/schema/bom/1.6}components/"
+                "{http://cyclonedx.org/schema/bom/1.6}component"
+            ),
+            message=(
+                "Unexpected child with tag '{http://cyclonedx.org/schema/bom/1.6}version' "
+                "at position 2. Tag 'bom:name' expected."
+            ),
+            rule="FR-03",
+        )
+        result = ValidationResult(
+            status=ValidationStatus.FAIL,
+            file_path="/tmp/bom.xml",
+            format_detected="cyclonedx",
+            issues=(xml_issue,),
+        )
+        html = self._load_html(result, tmp_path)
+        assert "/bom/components/component" in html
+        assert "{http://cyclonedx.org/schema/bom/1.6}" not in html
+        assert "Element &#x27;name&#x27;" in html or "Element 'name'" in html
+
+    def test_html_hides_ntia_rule_ids_and_adds_supplier_hint(self, tmp_path: Path) -> None:
+        ntia_issue = ValidationIssue(
+            severity=IssueSeverity.ERROR,
+            field_path="components[0].supplier",
+            message="Component 'requests' is missing a supplier name (NTIA FR-04)",
+            rule="FR-04",
+        )
+        result = ValidationResult(
+            status=ValidationStatus.FAIL,
+            file_path="/tmp/bom.json",
+            format_detected="cyclonedx",
+            issues=(ntia_issue,),
+        )
+        html = self._load_html(result, tmp_path)
+        assert "NTIA FR-04" not in html
+        assert "provide a supplier/organization name" in html
+        assert "<th>Hint</th>" in html
+        assert "Component &#x27;requests&#x27; is missing a supplier name." in html or "Component 'requests' is missing a supplier name." in html
+
+    def test_html_places_message_and_hint_in_separate_columns(self, tmp_path: Path) -> None:
+        xml_issue = ValidationIssue(
+            severity=IssueSeverity.ERROR,
+            field_path="packages.0",
+            message="'SPDXID' is a required property",
+            rule="FR-02",
+        )
+        result = ValidationResult(
+            status=ValidationStatus.FAIL,
+            file_path="/tmp/bom.json",
+            format_detected="spdx",
+            issues=(xml_issue,),
+        )
+        html = self._load_html(result, tmp_path)
+        assert "Missing required field &#x27;SPDXID&#x27;." in html or "Missing required field 'SPDXID'." in html
+        assert "add &#x27;SPDXID&#x27; at this location." in html or "add 'SPDXID' at this location." in html
+
 
 # ===========================================================================
 # TestReturnValue

--- a/tests/unit/test_report_writer.py
+++ b/tests/unit/test_report_writer.py
@@ -463,7 +463,7 @@ class TestToolVersionFallback:
 
     def test_tool_version_fallback_when_package_not_found(self, tmp_path: Path) -> None:
         """When importlib.metadata.version raises PackageNotFoundError,
-        _tool_version() must return the hardcoded fallback '0.2.0'."""
+        _tool_version() must return the fallback 'unknown'."""
         from sbom_validator.report_writer import _tool_version
 
         with patch(
@@ -472,7 +472,7 @@ class TestToolVersionFallback:
         ):
             version = _tool_version()
 
-        assert version == "0.2.0"
+        assert version == "unknown"
 
     def test_write_reports_uses_fallback_version_in_json(self, tmp_path: Path) -> None:
         """When the package is not installed, write_reports must still produce a
@@ -484,4 +484,4 @@ class TestToolVersionFallback:
             _, json_path = write_reports(_pass_result(), tmp_path)
 
         data = json.loads(json_path.read_text(encoding="utf-8"))
-        assert data["tool_version"] == "0.2.0"
+        assert data["tool_version"] == "unknown"

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -59,6 +59,11 @@ def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _load_text(path: Path) -> str:
+    """Load a text fixture file and return the raw contents."""
+    return path.read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # TestValidateSchemaSPDX
 # ---------------------------------------------------------------------------
@@ -205,6 +210,17 @@ class TestValidateSchemaCycloneDX:
             assert (
                 issue.field_path.strip() != ""
             ), "issue.field_path must not be empty or whitespace-only"
+
+    def test_valid_cyclonedx_xml_returns_empty_list(self, cdx_fixtures: Path) -> None:
+        xml_doc = _load_text(cdx_fixtures / "valid-minimal.cdx.xml")
+        result = validate_schema(xml_doc, "cyclonedx")
+        assert result == []
+
+    def test_invalid_cyclonedx_xml_returns_issues(self, cdx_fixtures: Path) -> None:
+        xml_doc = _load_text(cdx_fixtures / "invalid-schema.cdx.xml")
+        result = validate_schema(xml_doc, "cyclonedx")
+        assert len(result) > 0
+        assert {issue.rule for issue in result} == {"FR-03"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -237,6 +237,7 @@ class TestValidatorErrorScenarios:
     def test_nonexistent_file_returns_error(self, tmp_path: Path) -> None:
         result = validate(tmp_path / "nonexistent.json")
         assert result.status == ValidationStatus.ERROR
+        assert len(result.issues) >= 1
 
     def test_nonexistent_file_does_not_raise(self, tmp_path: Path) -> None:
         # The orchestrator must convert all exceptions to ERROR results
@@ -254,6 +255,7 @@ class TestValidatorErrorScenarios:
         bad_file.write_text("not json", encoding="utf-8")
         result = validate(bad_file)
         assert result.status == ValidationStatus.ERROR
+        assert len(result.issues) >= 1
 
     def test_invalid_json_does_not_raise(self, tmp_path: Path) -> None:
         bad_file = tmp_path / "bad.json"
@@ -268,6 +270,7 @@ class TestValidatorErrorScenarios:
         unknown.write_text('{"neither": "spdx nor cyclonedx"}', encoding="utf-8")
         result = validate(unknown)
         assert result.status == ValidationStatus.ERROR
+        assert len(result.issues) >= 1
 
     def test_unknown_format_does_not_raise(self, tmp_path: Path) -> None:
         unknown = tmp_path / "unknown.json"

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -63,6 +63,12 @@ class TestValidatorPassScenarios:
         result = validate(CDX_FIXTURES / "valid-full.cdx.json")
         assert result.issues == ()
 
+    def test_valid_cyclonedx_xml_minimal_returns_pass(self) -> None:
+        result = validate(CDX_FIXTURES / "valid-minimal.cdx.xml")
+        assert result.status == ValidationStatus.PASS
+        assert result.issues == ()
+        assert result.format_detected == "cyclonedx"
+
     def test_pass_result_has_correct_file_path(self) -> None:
         result = validate(SPDX_FIXTURES / "valid-minimal.spdx.json")
         assert "valid-minimal.spdx.json" in result.file_path
@@ -114,6 +120,12 @@ class TestValidatorSchemaFailScenarios:
 
     def test_invalid_cdx_schema_issues_have_fr03_rule(self) -> None:
         result = validate(CDX_FIXTURES / "invalid-schema.cdx.json")
+        assert all(i.rule == "FR-03" for i in result.issues)
+
+    def test_invalid_cdx_xml_schema_issues_have_fr03_rule(self) -> None:
+        result = validate(CDX_FIXTURES / "invalid-schema.cdx.xml")
+        assert result.status == ValidationStatus.FAIL
+        assert len(result.issues) > 0
         assert all(i.rule == "FR-03" for i in result.issues)
 
     def test_schema_fail_has_no_ntia_issues(self) -> None:
@@ -176,6 +188,10 @@ class TestValidatorNtiaFailScenarios:
 
     def test_missing_supplier_cdx_returns_fail(self) -> None:
         result = validate(CDX_FIXTURES / "missing-supplier.cdx.json")
+        assert result.status == ValidationStatus.FAIL
+
+    def test_missing_supplier_cdx_xml_returns_fail(self) -> None:
+        result = validate(CDX_FIXTURES / "missing-supplier.cdx.xml")
         assert result.status == ValidationStatus.FAIL
 
     def test_missing_timestamp_cdx_returns_fail(self) -> None:


### PR DESCRIPTION
## Summary

- **CycloneDX 1.6 XML support**: detection, strict XSD schema validation, and parser normalization — full parity with existing JSON pipeline
- **UX report improvements**: humanized field paths (namespace-stripped), NTIA rule IDs removed from user-facing output, actionable hints added, and a dedicated Hint column in HTML reports
- **Sandbox demo SBOMs**: reusable CycloneDX JSON/XML and SPDX valid/invalid fixtures in `sandbox/user-demo/`
- **Release tracker**: `docs/releases/TASKS-v0.2.1.md` documents all gate evidence

## Test plan

- [x] `poetry run ruff check .` — clean
- [x] `poetry run black --check .` — clean
- [x] `poetry run mypy src/` — clean
- [x] `poetry run pytest` — **501 passed**
- [x] Smoke-tested all sandbox scenarios (CycloneDX XML PASS/FAIL, SPDX PASS/schema-fail/conformance-fail)
- [x] Confirmed HTML reports show separate Message and Hint columns
- [x] Confirmed JSON output still includes full `rule` field for automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)